### PR TITLE
Fix ChromeOS lint + seed alpha bug automation

### DIFF
--- a/.github/workflows/publish-alpha-bugs.yml
+++ b/.github/workflows/publish-alpha-bugs.yml
@@ -1,0 +1,70 @@
+name: Publish Alpha Bug Baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "If true, only log which issues would be created."
+        required: false
+        default: "false"
+        type: boolean
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync alpha bug issues
+        uses: actions/github-script@v7
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = 'docs/alpha-bugs.json';
+            if (!fs.existsSync(path)) {
+              core.setFailed(`Missing ${path}; nothing to publish.`);
+              return;
+            }
+            const bugs = JSON.parse(fs.readFileSync(path, 'utf8'));
+            if (!Array.isArray(bugs) || bugs.length === 0) {
+              core.info('No bugs defined; skipping.');
+              return;
+            }
+
+            const dryRun = (process.env.DRY_RUN || 'false').toLowerCase() === 'true';
+            const { owner, repo } = context.repo;
+
+            for (const bug of bugs) {
+              if (!bug.title || !bug.body) {
+                core.warning(`Skipping malformed entry: ${JSON.stringify(bug)}`);
+                continue;
+              }
+
+              const search = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${owner}/${repo} is:issue "${bug.title}" in:title`
+              });
+
+              const existing = search.data.items.find(item => item.title.toLowerCase() === bug.title.toLowerCase() && item.state === 'open');
+              if (existing) {
+                core.info(`Issue already exists for "${bug.title}" (#${existing.number}); skipping.`);
+                continue;
+              }
+
+              if (dryRun) {
+                core.info(`[DRY RUN] Would create issue "${bug.title}" with labels ${(bug.labels || []).join(', ') || '(none)'}.`);
+                continue;
+              }
+
+              const response = await github.rest.issues.create({
+                owner,
+                repo,
+                title: bug.title,
+                body: bug.body,
+                labels: bug.labels || ['bug']
+              });
+              core.info(`Created issue #${response.data.number} for "${bug.title}".`);
+            }

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.telephony" android:required="false" />
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />

--- a/androidApp/src/main/java/com/pulselink/ui/ads/NativeAdCard.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/ads/NativeAdCard.kt
@@ -84,7 +84,8 @@ fun NativeAdCard(
         AndroidView(
             modifier = Modifier.fillMaxWidth(),
             factory = { ctx ->
-                (LayoutInflater.from(ctx).inflate(R.layout.native_ad_view, null) as NativeAdView).apply {
+                NativeAdView(ctx).apply {
+                    LayoutInflater.from(ctx).inflate(R.layout.native_ad_view, this, true)
                     bindNativeAd(this, ad)
                 }
             },

--- a/docs/alpha-bugs.json
+++ b/docs/alpha-bugs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "title": "ChromeOS builds fail without optional telephony feature flag",
+    "labels": [
+      "bug",
+      "alpha-baseline"
+    ],
+    "body": "### Impact\nChromebooks reject the Alpha build because the manifest requests SMS/phone permissions without declaring \\\"<uses-feature android:name=\\\"android.hardware.telephony\\\" android:required=\\\"false\\\" />\\\", so Play Store flags the app as requiring telephony hardware and blocks install on ChromeOS.\n\n### Reproduction\n1. Install the current APK on a Chromebook or run `./gradlew androidApp:lint`.\n2. Observe lint error `PermissionImpliesUnsupportedChromeOsHardware` and the install refusal.\n\n### Fix\nDeclare the telephony feature as optional alongside the microphone feature in `androidApp/src/main/AndroidManifest.xml`."
+  },
+  {
+    "title": "Native ad card collapses because layout inflated without parent",
+    "labels": [
+      "bug",
+      "alpha-baseline"
+    ],
+    "body": "### Impact\nNative ads render with incorrect width and clipped rounded corners because `NativeAdCard` inflates `R.layout.native_ad_view` with a null parent, so the layout params on the root container are ignored by Compose's `Card`.\n\n### Reproduction\n1. Enable ad loading (Free flavor with ads enabled) and open the Upgrade to Pro screen.\n2. The native ad view floats with minimal width or loses its padding.\n\n### Fix\nInflate the layout into a concrete `NativeAdView` instance before binding so the composed card can honor its layout params (`androidApp/src/main/java/com/pulselink/ui/ads/NativeAdCard.kt`)."
+  }
+]


### PR DESCRIPTION
## Summary
- declare telephony hardware as optional to satisfy ChromeOS + lint
- fix NativeAdCard parent inflation
- seed alpha bug JSON + workflow-driven issue sync

## Testing
- `./gradlew lint`
- `./gradlew test`
