### PR TITLE
Grant issue write perms to alpha bug workflow

### DIFF
--- a/.github/workflows/publish-alpha-bugs.yml
+++ b/.github/workflows/publish-alpha-bugs.yml
@@ -9,6 +9,10 @@ on:
         default: "false"
         type: boolean
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- request `issues: write` for the alpha bug publishing workflow

## Testing
- rerun `Publish Alpha Bug Baseline` after merge