### PR TITLE
Handle inbox shortcut reentry intent

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -394,6 +394,7 @@ kapt {
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test:core:1.5.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.test.espresso:espresso-intents:3.5.1")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation("com.google.dagger:hilt-android-testing:2.51.1")
     kaptAndroidTest("com.google.dagger:hilt-compiler:2.51.1")

--- a/androidApp/src/androidTest/java/com/pulselink/ui/InboxLauncherActivityTest.kt
+++ b/androidApp/src/androidTest/java/com/pulselink/ui/InboxLauncherActivityTest.kt
@@ -1,0 +1,51 @@
+package com.pulselink.ui
+
+import android.content.Intent
+import androidx.test.core.app.ActivityScenarioRule
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.Matchers.allOf
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class InboxLauncherActivityTest {
+
+    @get:Rule
+    val scenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Before
+    fun setUp() {
+        Intents.init()
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+    }
+
+    @Test
+    fun launchingInboxShortcutSendsNewIntentToMainActivity() {
+        scenarioRule.scenario.onActivity { activity ->
+            val launcherIntent = Intent(activity, InboxLauncherActivity::class.java)
+            activity.startActivity(launcherIntent)
+        }
+
+        Intents.intended(
+            allOf(
+                hasComponent(MainActivity::class.java.name),
+                hasExtra("open_sms_inbox", true)
+            )
+        )
+
+        scenarioRule.scenario.onActivity { activity ->
+            assertTrue(activity.intent?.getBooleanExtra("open_sms_inbox", false) == true)
+        }
+    }
+}

--- a/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
@@ -134,6 +134,7 @@ class MainActivity : AppCompatActivity() {
     private val inboxShortcutFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
+        setIntent(intent)
         if (intent?.getBooleanExtra("open_sms_inbox", false) == true) {
             inboxShortcutFlow.tryEmit(Unit)
         }
@@ -194,6 +195,7 @@ class MainActivity : AppCompatActivity() {
                 val defaultSmsSupported = remember {
                     defaultSmsHelper.buildRoleRequestIntent() != null || defaultSmsHelper.isDefaultSms()
                 }
+                val initialInboxShortcut = intent?.getBooleanExtra("open_sms_inbox", false) == true
                 val requestDefaultSms = remember(defaultSmsLauncher) {
                     {
                         val intent = defaultSmsHelper.buildRoleRequestIntent()
@@ -208,11 +210,10 @@ class MainActivity : AppCompatActivity() {
                         }
                     }
                 }
-                val openInboxShortcut = remember { intent?.getBooleanExtra("open_sms_inbox", false) == true }
                 LaunchedEffect(Unit) {
                     isDefaultSms = defaultSmsHelper.isDefaultSms()
                     missingSmsPerms = requiredSmsPermissions(context)
-                    if (openInboxShortcut) inboxShortcutFlow.tryEmit(Unit)
+                    if (initialInboxShortcut) inboxShortcutFlow.tryEmit(Unit)
                 }
                 LaunchedEffect(navController) {
                     inboxShortcutFlow.collectLatest {
@@ -453,8 +454,8 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
 
-                val startDestination = remember(openInboxShortcut, authState, state.onboardingComplete) {
-                    if (openInboxShortcut && authState is AuthState.Authenticated && state.onboardingComplete) {
+                val startDestination = remember(initialInboxShortcut, authState, state.onboardingComplete) {
+                    if (initialInboxShortcut && authState is AuthState.Authenticated && state.onboardingComplete) {
                         "sms/inbox"
                     } else {
                         "splash"


### PR DESCRIPTION
## Summary
- ensure the inbox shortcut intent updates MainActivity state whenever a new intent arrives and routes through the permission checks before navigation
- add an instrumentation check that launching InboxLauncherActivity while MainActivity is active issues the inbox intent back to the running activity
- include Espresso Intents dependency to verify the shortcut intent payload

## Testing
- bash gradlew testFreeDebugUnitTest --console=plain --no-daemon *(hangs/terminated; command could not complete in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f74a4cea08326859f17015c2c3527)