### PR TITLE
feat: standardize message ordering across conversation screens

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/screens/ContactConversationScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/ContactConversationScreen.kt
@@ -306,6 +306,7 @@ private fun ConversationBody(
                 .fillMaxWidth()
                 .weight(1f),
             state = listState,
+                        reverseLayout = true,
             verticalArrangement = Arrangement.spacedBy(16.dp),
             contentPadding = PaddingValues(vertical = 8.dp)
         ) {

--- a/beaconApp/src/main/java/com/pulselink/beacon/ui/ThreadScreen.kt
+++ b/beaconApp/src/main/java/com/pulselink/beacon/ui/ThreadScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -36,6 +37,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -43,6 +47,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import kotlinx.coroutines.launch
 import com.pulselink.beacon.data.SmsMessageItem
 import com.pulselink.beacon.data.ThemePalette
 import com.pulselink.beacon.ui.ads.NativeAdCard
@@ -61,6 +66,17 @@ fun ThreadScreen(
 ) {
     var draft by remember { mutableStateOf("") }
     val iconTint = theme.accentColor
+
+        val listState = remember(address) { LazyListState() }
+            val scope = rememberCoroutineScope()
+                var initialScrollDone by remember(address) { mutableStateOf(false) }
+                    val isNearBottom by remember {
+                                derivedStateOf {
+                                                val layout = listState.layoutInfo
+                                                            val lastVisible = layout.visibleItemsInfo.lastOrNull()?.index ?: 0
+                                                                        lastVisible >= (layout.totalItemsCount - 2).coerceAtLeast(0)
+                                                                                }
+                                                                                    }
 
     Scaffold(
         topBar = {
@@ -102,6 +118,8 @@ fun ThreadScreen(
                     .weight(1f)
                     .fillMaxWidth()
                     .padding(horizontal = 12.dp),
+                                state = listState,
+                                            reverseLayout = true,
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(messages, key = { it.id }) { msg ->
@@ -118,6 +136,13 @@ fun ThreadScreen(
                 }
                 item { Spacer(modifier = Modifier.height(40.dp)) }
             }
+
+                    LaunchedEffect(messages.size) {
+                                    if (messages.isNotEmpty() && (!initialScrollDone || isNearBottom)) {
+                                                        listState.animateScrollToItem(0)
+                                                                        initialScrollDone = true
+                                                                                    }
+                                                                                            }
 
             Surface(
                 tonalElevation = 2.dp,


### PR DESCRIPTION
- Add reverseLayout=true to ContactConversationScreen LazyColumn
- Add state management and reverseLayout to Beacon ThreadScreen
- Implement smart auto-scroll behavior (only scrolls when at bottom)
- Messages now display with newest at bottom (standard chat UX)