### PR TITLE
fix(ios): use Text type for badge modifier to fix Swift compilation

### DIFF
--- a/iosApp/PulseLinkiOS/ContentView.swift
+++ b/iosApp/PulseLinkiOS/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
                     .tabItem {
                         Label("Home", systemImage: "shield.lefthalf.filled")
                     }
-                    .badge(isPro ? "Pro" : nil)
+                    .badge(isPro ? Text("Pro") : nil)
 
                 if isPro {
                     ContactsTab(viewModel: viewModel, selectedContact: $selectedContact)


### PR DESCRIPTION
The .badge() modifier expects Text? not String?. The ternary expression
`isPro ? "Pro" : nil` evaluates to String? which doesn't implicitly
convert to Text?. Wrapping in Text() constructor fixes the type mismatch.