### PR TITLE
Fix Widget on Pro/Premium and Watch Build

### DIFF
--- a/androidApp/src/premium/AndroidManifest.xml
+++ b/androidApp/src/premium/AndroidManifest.xml
@@ -7,6 +7,28 @@
         <provider
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
+
+        <!-- Home screen widget (available in all flavors, incl. Pro) -->
+        <receiver
+            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
+            android:exported="true"
+            android:icon="@drawable/widget_logo"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_info" />
+        </receiver>
+        <receiver
+            android:name=".widget.PulseLinkWidgetActionReceiver"
+            android:exported="false" />
+
+        <service
+            android:name=".widget.PulseLinkWidgetService"
+            android:permission="android.permission.BIND_REMOTEVIEWS"
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -6,6 +6,28 @@
         <provider
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
+
+        <!-- Home screen widget (available in all flavors, incl. Pro) -->
+        <receiver
+            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
+            android:exported="true"
+            android:icon="@drawable/widget_logo"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_info" />
+        </receiver>
+        <receiver
+            android:name=".widget.PulseLinkWidgetActionReceiver"
+            android:exported="false" />
+
+        <service
+            android:name=".widget.PulseLinkWidgetService"
+            android:permission="android.permission.BIND_REMOTEVIEWS"
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -70,3 +70,16 @@ dependencies {
     implementation("androidx.credentials:credentials-play-services-auth:1.5.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
 }
+
+// Automatically copy google-services.json from secure folders if present.
+val sourceFile = rootProject.file("PRO-CERTS/google-services-premium.json")
+tasks.register("syncGoogleServices", Copy::class) {
+    onlyIf { sourceFile.exists() }
+    from(sourceFile)
+    into(projectDir)
+    rename { "google-services.json" }
+}
+
+tasks.matching { it.name == "preBuild" }.configureEach {
+    dependsOn("syncGoogleServices")
+}


### PR DESCRIPTION
This PR addresses two open issues:
1.  **Issue #76:** The widget was missing on the Pro flavor (and Premium). This was caused by the widget components being declared only in the `main` manifest but apparently needing explicit declaration in flavor manifests for this project setup. The widget components have been added to `pro` and `premium` manifests.
2.  **Issue #68:** The Watch app failed to build due to the missing `google-services.json`. A Gradle task has been added to `wearApp/build.gradle.kts` to automatically copy the file from `PRO-CERTS/google-services-premium.json` before the build, mirroring the setup in `androidApp`.

---
*PR created automatically by Jules for task [15590539250013480835](https://jules.google.com/task/15590539250013480835) started by @DamienLove*