### PR TITLE
Enable Incoming SMS Sync for Non-Default App Users

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -414,6 +414,7 @@
             android:permission="android.permission.BROADCAST_SMS">
             <intent-filter android:priority="999">
                 <action android:name="android.provider.Telephony.SMS_DELIVER" />
+                <action android:name="android.provider.Telephony.SMS_RECEIVED" />
             </intent-filter>
         </receiver>
 

--- a/androidApp/src/main/java/com/pulselink/receiver/PulseLinkSmsReceiver.kt
+++ b/androidApp/src/main/java/com/pulselink/receiver/PulseLinkSmsReceiver.kt
@@ -50,7 +50,7 @@ class PulseLinkSmsReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action
-        if (action != Telephony.Sms.Intents.SMS_DELIVER_ACTION) {
+        if (action != Telephony.Sms.Intents.SMS_DELIVER_ACTION && action != Telephony.Sms.Intents.SMS_RECEIVED_ACTION) {
             return
         }
         val messages = Telephony.Sms.Intents.getMessagesFromIntent(intent)
@@ -62,12 +62,23 @@ class PulseLinkSmsReceiver : BroadcastReceiver() {
         val pendingResult = goAsync()
         CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
             try {
-                try {
-                    smsStore.insertIncoming(origin, body, timestamp)
-                    // SmsStore triggers sync internally
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to insert incoming SMS from $origin", e)
+                if (action == Telephony.Sms.Intents.SMS_DELIVER_ACTION) {
+                    try {
+                        smsStore.insertIncoming(origin, body, timestamp)
+                        // SmsStore triggers sync internally
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to insert incoming SMS from $origin", e)
+                    }
+                } else {
+                    // SMS_RECEIVED: Default SMS app handles insert/notify.
+                    // We only need to ensure sync triggers.
+                    // SmsSyncManager observes changes, but we trigger explicitly to be safe/faster.
+                    val threadId = runCatching {
+                        Telephony.Threads.getOrCreateThreadId(context, origin)
+                    }.getOrNull()
+                    smsSyncTrigger.triggerSync(threadId)
                 }
+
                 val settings = settingsRepository.settings.first()
                 val completed = withTimeoutOrNull(8_000L) {
                     val parsed = SmsCodec.parse(body)
@@ -113,17 +124,20 @@ class PulseLinkSmsReceiver : BroadcastReceiver() {
                         }
 
                         handleTrustedSms(origin, body, settings)
-                        val threadId = runCatching {
-                            Telephony.Threads.getOrCreateThreadId(context, origin)
-                        }.getOrNull()
-                        MessageNotificationManager.notifyIncoming(
-                            context = context,
-                            address = origin,
-                            body = body,
-                            timestamp = timestamp,
-                            settings = settings,
-                            threadId = threadId
-                        )
+
+                        if (action == Telephony.Sms.Intents.SMS_DELIVER_ACTION) {
+                            val threadId = runCatching {
+                                Telephony.Threads.getOrCreateThreadId(context, origin)
+                            }.getOrNull()
+                            MessageNotificationManager.notifyIncoming(
+                                context = context,
+                                address = origin,
+                                body = body,
+                                timestamp = timestamp,
+                                settings = settings,
+                                threadId = threadId
+                            )
+                        }
                     }
                 }
                 if (completed == null) {


### PR DESCRIPTION
Enables real-time incoming SMS synchronization for premium users who do not use PulseLink as their default SMS application. By listening to `SMS_RECEIVED`, the app wakes up, processes critical passive features (like Emergency Alerts and OTPs), and triggers a cloud sync, while delegating storage and notification responsibility to the system's default SMS app.

---
*PR created automatically by Jules for task [15085403535726434712](https://jules.google.com/task/15085403535726434712) started by @DamienLove*