### PR TITLE
🎨 Palette: Add live regions for search results

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-28 - Image Load Error Fallbacks
 **Learning:** User-provided URLs for avatars often break (404s), resulting in ugly browser-default broken image icons that degrade perceived app quality. Relying solely on "if URL exists" logic is insufficient.
 **Action:** Implemented a `useState` + `onError` handler pattern in the `Avatar` component to detect load failures and automatically revert to the deterministic initial fallback, maintaining UI elegance even with bad data.
+
+## 2026-01-27 - Live Filter Feedback
+**Learning:** In dynamic search lists (like Contacts or Themes), sighted users see the list shrink immediately, but screen reader users get no feedback that the filter worked or how many items remain.
+**Action:** Use `aria-live="polite"` on the result count element and `role="status"` on empty state messages to announce changes or "No results found" without user intervention.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2059,7 +2059,7 @@ const Sidebar = memo(({
             {isLoadingThreads ? (
                Array.from({ length: 5 }).map((_, i) => <ThreadSkeleton key={i} />)
             ) : filteredThreads.length === 0 ? (
-              <div className="sidebar-placeholder">
+              <div className="sidebar-placeholder" role="status">
                 <div className="sidebar-tip">
                   <strong>{searchQuery ? "No matches found" : "No conversations found"}</strong>
                 </div>
@@ -4377,7 +4377,7 @@ function App() {
                 <p>Browse all device contacts synced from your phone.</p>
               </div>
               <div className="contacts-toolbar">
-                <div className="contact-count" style={{ marginBottom: 12, fontSize: '0.9em', color: 'var(--muted)' }}>
+                <div className="contact-count" style={{ marginBottom: 12, fontSize: '0.9em', color: 'var(--muted)' }} aria-live="polite" aria-atomic="true">
                   {filteredDeviceContacts.length} contact{filteredDeviceContacts.length === 1 ? '' : 's'}
                 </div>
                 <div className="settings-search-container" style={{ flex: 1, marginBottom: 0 }}>
@@ -4419,7 +4419,7 @@ function App() {
                   </button>
                 )}
                 {filteredDeviceContacts.length === 0 && (
-                  <div className="settings-note">
+                  <div className="settings-note" role="status">
                     {contactSearch.trim() ? (
                       <>
                         No contacts match that search.
@@ -4659,7 +4659,7 @@ function App() {
                       />
                     ))}
                     {filteredThemes.length === 0 && (
-                      <div className="theme-empty">
+                      <div className="theme-empty" role="status">
                         No themes found.
                       </div>
                     )}

--- a/web/tests/palette_a11y.spec.js
+++ b/web/tests/palette_a11y.spec.js
@@ -1,0 +1,51 @@
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Palette A11y Enhancements', () => {
+  test.beforeEach(async ({ page }) => {
+    // Enable mock user mode
+    await page.goto('/?mock_user=true');
+    await page.waitForTimeout(1000);
+  });
+
+  test('Contacts search results should have live region attributes', async ({ page }) => {
+    await page.locator('.nav-item[title="Contacts"]').click();
+
+    // Verify contact count has live region attributes
+    const contactCount = page.locator('.contact-count');
+    await expect(contactCount).toBeVisible();
+    await expect(contactCount).toHaveAttribute('aria-live', 'polite');
+    await expect(contactCount).toHaveAttribute('aria-atomic', 'true');
+
+    // Search for non-existent contact
+    const searchInput = page.locator('.settings-search-input');
+    await searchInput.fill('NonExistentContactXYZ');
+
+    // Verify empty state has role="status"
+    const emptyState = page.locator('.settings-note[role="status"]');
+    await expect(emptyState).toBeVisible();
+    await expect(emptyState).toContainText('No contacts match that search');
+  });
+
+  test('Sidebar search empty state should have role status', async ({ page }) => {
+    await page.locator('.nav-item[title="Beacon"]').click();
+
+    const searchInput = page.locator('.sidebar-search-input-field');
+    await searchInput.fill('NonExistentThreadXYZ');
+
+    const emptyState = page.locator('.sidebar-placeholder[role="status"]');
+    await expect(emptyState).toBeVisible();
+    await expect(emptyState).toContainText('No matches found');
+  });
+
+  test('Themes search empty state should have role status', async ({ page }) => {
+    await page.locator('.nav-item[title="Themes"]').click();
+
+    const searchInput = page.locator('.settings-search-input');
+    await searchInput.fill('NonExistentThemeXYZ');
+
+    const emptyState = page.locator('.theme-empty[role="status"]');
+    await expect(emptyState).toBeVisible();
+    await expect(emptyState).toContainText('No themes found');
+  });
+});


### PR DESCRIPTION
This PR implements a micro-UX improvement for screen reader users by adding live regions to search result counts and empty state messages. When a user filters lists (Contacts, Threads, Themes), the application now announces the result count or "No results found" immediately, providing comparable feedback to sighted users.

Changes:
- `web/src/App.jsx`: Added `aria-live` and `role="status"` attributes.
- `web/tests/palette_a11y.spec.js`: Added new test suite for accessibility attributes.
- `.Jules/palette.md`: Recorded learning about live filter feedback.

---
*PR created automatically by Jules for task [6306502072135919475](https://jules.google.com/task/6306502072135919475) started by @DamienLove*