### PR TITLE
Match iOS build functionality and look with Android

### DIFF
--- a/iosApp/BeaconiOS/AdBanner.swift
+++ b/iosApp/BeaconiOS/AdBanner.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+#if canImport(GoogleMobileAds)
+import GoogleMobileAds
+
+struct AdBanner: UIViewRepresentable {
+    func makeUIView(context: Context) -> GADBannerView {
+        let banner = GADBannerView(adSize: GADAdSizeBanner)
+        banner.adUnitID = "ca-app-pub-3940256099942544/2934735716" // Test ID
+
+        // Root view controller is required for ad presentation
+        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let rootViewController = scene.windows.first?.rootViewController {
+            banner.rootViewController = rootViewController
+        }
+
+        banner.load(GADRequest())
+        return banner
+    }
+
+    func updateUIView(_ uiView: GADBannerView, context: Context) {}
+}
+#else
+struct AdBanner: View {
+    var body: some View {
+        EmptyView()
+    }
+}
+#endif

--- a/iosApp/BeaconiOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iosApp/BeaconiOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,7 @@
+{
+  "images" : [],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/BeaconiOS/Assets.xcassets/Contents.json
+++ b/iosApp/BeaconiOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/BeaconiOS/ContentView.swift
+++ b/iosApp/BeaconiOS/ContentView.swift
@@ -17,34 +17,41 @@ struct ContentView: View {
 
     var body: some View {
         if viewModel.isLoggedIn {
-            TabView {
-                BeaconTab(viewModel: viewModel, filter: .inbox)
-                    .tabItem {
-                        Label("Inbox", systemImage: "bubble.left.and.bubble.right.fill")
-                    }
-                    .badge(isPro ? "Pro" : nil)
-
-                BeaconTab(viewModel: viewModel, filter: .trusted)
-                    .tabItem {
-                        Label("Trusted", systemImage: "shield.fill")
-                    }
-
-                BeaconTab(viewModel: viewModel, filter: .favorites)
-                    .tabItem {
-                        Label("Favorites", systemImage: "star.fill")
-                    }
-
-                if isPro {
-                    BeaconTab(viewModel: viewModel, filter: .private)
+            VStack(spacing: 0) {
+                TabView {
+                    BeaconTab(viewModel: viewModel, filter: .inbox)
                         .tabItem {
-                            Label("Private", systemImage: "lock.fill")
+                            Label("Inbox", systemImage: "bubble.left.and.bubble.right.fill")
+                        }
+                        .badge(isPro ? "Pro" : nil)
+
+                    BeaconTab(viewModel: viewModel, filter: .trusted)
+                        .tabItem {
+                            Label("Trusted", systemImage: "shield.fill")
+                        }
+
+                    BeaconTab(viewModel: viewModel, filter: .favorites)
+                        .tabItem {
+                            Label("Favorites", systemImage: "star.fill")
+                        }
+
+                    if isPro {
+                        BeaconTab(viewModel: viewModel, filter: .private)
+                            .tabItem {
+                                Label("Private", systemImage: "lock.fill")
+                            }
+                    }
+
+                    SettingsTab(viewModel: viewModel, isPro: isPro)
+                        .tabItem {
+                            Label("Settings", systemImage: "gear")
                         }
                 }
 
-                SettingsTab(viewModel: viewModel, isPro: isPro)
-                    .tabItem {
-                        Label("Settings", systemImage: "gear")
-                    }
+                if !isPro {
+                    AdBanner()
+                        .frame(height: 50)
+                }
             }
         } else {
             LoginView {

--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -12,6 +12,7 @@ end
 
 target 'PulseLinkFree' do
   shared_pods
+  pod 'Google-Mobile-Ads-SDK'
 end
 
 target 'PulseLinkPro' do
@@ -20,6 +21,7 @@ end
 
 target 'BeaconFree' do
   shared_pods
+  pod 'Google-Mobile-Ads-SDK'
 end
 
 target 'BeaconPro' do

--- a/iosApp/PulseLinkiOS/AdBanner.swift
+++ b/iosApp/PulseLinkiOS/AdBanner.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+#if canImport(GoogleMobileAds)
+import GoogleMobileAds
+
+struct AdBanner: UIViewRepresentable {
+    func makeUIView(context: Context) -> GADBannerView {
+        let banner = GADBannerView(adSize: GADAdSizeBanner)
+        banner.adUnitID = "ca-app-pub-3940256099942544/2934735716" // Test ID
+
+        // Root view controller is required for ad presentation
+        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let rootViewController = scene.windows.first?.rootViewController {
+            banner.rootViewController = rootViewController
+        }
+
+        banner.load(GADRequest())
+        return banner
+    }
+
+    func updateUIView(_ uiView: GADBannerView, context: Context) {}
+}
+#else
+struct AdBanner: View {
+    var body: some View {
+        EmptyView()
+    }
+}
+#endif

--- a/iosApp/PulseLinkiOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iosApp/PulseLinkiOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,7 @@
+{
+  "images" : [],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/PulseLinkiOS/Assets.xcassets/Contents.json
+++ b/iosApp/PulseLinkiOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/PulseLinkiOS/ContentView.swift
+++ b/iosApp/PulseLinkiOS/ContentView.swift
@@ -20,27 +20,34 @@ struct ContentView: View {
 
     var body: some View {
         if viewModel.isLoggedIn {
-            TabView {
-                HomeTab(viewModel: viewModel,
-                        showCancelSheet: $showCancelSheet,
-                        pinInput: $pinInput,
-                        isPro: isPro)
-                    .tabItem {
-                        Label("Home", systemImage: "shield.lefthalf.filled")
-                    }
-                    .badge(isPro ? Text("Pro") : nil)
-
-                if isPro {
-                    ContactsTab(viewModel: viewModel, selectedContact: $selectedContact)
+            VStack(spacing: 0) {
+                TabView {
+                    HomeTab(viewModel: viewModel,
+                            showCancelSheet: $showCancelSheet,
+                            pinInput: $pinInput,
+                            isPro: isPro)
                         .tabItem {
-                            Label("Contacts", systemImage: "person.2.fill")
+                            Label("Home", systemImage: "shield.lefthalf.filled")
+                        }
+                        .badge(isPro ? Text("Pro") : nil)
+
+                    if isPro {
+                        ContactsTab(viewModel: viewModel, selectedContact: $selectedContact)
+                            .tabItem {
+                                Label("Contacts", systemImage: "person.2.fill")
+                            }
+                    }
+
+                    SettingsTab(viewModel: viewModel)
+                        .tabItem {
+                            Label("Settings", systemImage: "gear")
                         }
                 }
 
-                SettingsTab(viewModel: viewModel)
-                    .tabItem {
-                        Label("Settings", systemImage: "gear")
-                    }
+                if !isPro {
+                    AdBanner()
+                        .frame(height: 50)
+                }
             }
             .sheet(isPresented: $showCancelSheet) {
                 CancelEmergencySheet(


### PR DESCRIPTION
This change brings the iOS build closer to Android parity by implementing:
1.  **Ad Support**: Adds Google Mobile Ads SDK to Free builds and displays banner ads in the main view. Pro builds are ad-free and do not link the Ad SDK.
2.  **Asset Structure**: Creates missing `Assets.xcassets` directories required for Xcode builds.
3.  **Feature Flags**: Leverages existing `project.yml` configuration (PRO flag) to toggle UI features and Ads.

The implementation uses `#if canImport(GoogleMobileAds)` to ensure `AdBanner` compiles correctly across all targets, preventing issues in Pro builds where the SDK is not present.

---
*PR created automatically by Jules for task [8950933339949643621](https://jules.google.com/task/8950933339949643621) started by @DamienLove*