### PR TITLE
🎨 Palette: Add smart SMS segment indicator

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -843,17 +843,22 @@ const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeL
           {body.length > 0 && (
             <div
               id="message-char-count"
+              role="status"
+              aria-live="polite"
               style={{
                 position: 'absolute',
                 bottom: '8px',
                 right: '12px',
                 fontSize: '0.75em',
-                color: 'var(--muted)',
+                color: body.length > 160 ? 'var(--warning)' : 'var(--muted)',
                 pointerEvents: 'none',
-                fontWeight: 500
+                fontWeight: 500,
+                transition: 'color 0.2s ease'
               }}
             >
-              {body.length}
+              {body.length > 160
+                ? `${body.length} / ${Math.ceil(body.length / 160)}`
+                : body.length}
             </div>
           )}
         </div>

--- a/web/tests/palette_ux.spec.js
+++ b/web/tests/palette_ux.spec.js
@@ -60,4 +60,20 @@ test.describe('Palette UX Enhancements', () => {
     await expect(hint).toHaveText('/');
     await expect(hint).toHaveAttribute('aria-hidden', 'true');
   });
+
+  test('Smart character count should show segments', async ({ page }) => {
+    await page.locator('.nav-item[title="Beacon"]').click();
+    await page.getByText('Test Contact').first().click();
+
+    const textarea = page.locator('.composer-textarea');
+    await expect(textarea).toBeVisible();
+
+    await textarea.fill('Hello world');
+    const counter = page.locator('#message-char-count');
+    await expect(counter).toHaveText('11');
+
+    const longText = 'a'.repeat(165);
+    await textarea.fill(longText);
+    await expect(counter).toHaveText('165 / 2');
+  });
 });


### PR DESCRIPTION
This PR enhances the SMS Message Composer by upgrading the character count indicator. 

**Changes:**
- **Smart Counter:** Instead of just showing the character count, it now calculates and displays SMS segments (e.g., "165 / 2") when the text length exceeds the standard 160-character limit.
- **Visual Feedback:** The counter color changes from muted gray to warning amber/yellow when the message splits into multiple segments, helping users be aware of potential costs or delivery behavior.
- **Accessibility:** Added `role="status"` and `aria-live="polite"` to ensuring screen readers announce the segment count when typing pauses, providing critical context to non-sighted users.
- **Testing:** Added a regression test case to `web/tests/palette_ux.spec.js` verifying the counter logic and display.

**Why:**
Users were previously unaware when their messages were being split into multiple SMS segments. This micro-UX improvement adds transparency and prevents "bill shock" or confusion about message delivery, while also making the app more accessible.

---
*PR created automatically by Jules for task [3309794542903827128](https://jules.google.com/task/3309794542903827128) started by @DamienLove*