### PR TITLE
Fix bug report URL and custom vibration persistence

### DIFF
--- a/androidApp/src/main/java/com/pulselink/data/settings/SettingsRepositoryImpl.kt
+++ b/androidApp/src/main/java/com/pulselink/data/settings/SettingsRepositoryImpl.kt
@@ -672,6 +672,10 @@ class SettingsRepositoryImpl @Inject constructor(
                 prefs[MESSAGE_NOTIFICATION_SOUND_OVERRIDES]
             ) { json.decodeFromString<Map<String, String>>(it) }
                 ?: PulseLinkSettings().messageNotificationSoundOverrides,
+            customVibrationPatternName = prefs[CUSTOM_VIBRATION_NAME],
+            customVibrationPattern = prefs[CUSTOM_VIBRATION_PATTERN]?.let { raw ->
+                decodeJsonOrNull(raw) { json.decodeFromString<List<Long>>(it) }
+            },
             betaAgreementAccepted = prefs[BETA_AGREEMENT_ACCEPTED] ?: PulseLinkSettings().betaAgreementAccepted,
             betaAgreementVersion = prefs[BETA_AGREEMENT_VERSION] ?: PulseLinkSettings().betaAgreementVersion,
             autoCallAfterAlert = prefs[AUTO_CALL] ?: PulseLinkSettings().autoCallAfterAlert,

--- a/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
@@ -1845,7 +1845,7 @@ class MainViewModel @Inject constructor(
         private const val REMOTE_BETA_AGREEMENT_TIMEOUT_MS = 10_000L
         private const val COLLECTION_USERS = "users"
         private const val COLLECTION_TRUSTED_CONTACTS = "trustedContacts"
-        const val BUG_REPORT_PAGE_URL = "https://github.com/DamienLove/pulselink/issues/new"
+        const val BUG_REPORT_PAGE_URL = "https://github.com/DamienLove/pulselink/issues/new?template=bug_report.md&labels=bug"
     }
 }
 


### PR DESCRIPTION
Fixed two issues identified in the open issues list:
1.  **Issue #362**: Bug report page was not directing to the correct location. Updated the URL to use the GitHub issue template.
2.  **Issue #534**: Custom vibrations could not be set. Fixed a bug in `SettingsRepositoryImpl` where custom vibration fields were missing from the `settingsValue` retrieval, causing them to be wiped out during any settings update.

---
*PR created automatically by Jules for task [11699380823805546058](https://jules.google.com/task/11699380823805546058) started by @DamienLove*