### PR TITLE
Fix RingerSong streaming integration and enable Apple/YouTube Music linking

### DIFF
--- a/ringersong/src/main/AndroidManifest.xml
+++ b/ringersong/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="audio/*" />
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
 

--- a/ringersong/src/main/java/com/RingerSong/free/MainActivity.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/MainActivity.kt
@@ -45,6 +45,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val sharedUriState = mutableStateOf<Uri?>(null)
+    private val sharedTextState = mutableStateOf<String?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,6 +53,7 @@ class MainActivity : ComponentActivity() {
         updateSharedIntent(intent)
         setContent {
             val sharedUri = remember { sharedUriState }
+            val sharedText = remember { sharedTextState }
             // Use hiltViewModel() instead of manually creating via factory
             val viewModel: RingerViewModel = hiltViewModel()
 
@@ -59,7 +61,11 @@ class MainActivity : ComponentActivity() {
                 RingerSongApp(
                     viewModel = viewModel,
                     sharedUri = sharedUri.value,
-                    onSharedConsumed = { sharedUri.value = null }
+                    sharedText = sharedText.value,
+                    onSharedConsumed = {
+                        sharedUri.value = null
+                        sharedText.value = null
+                    }
                 )
             }
         }
@@ -81,12 +87,25 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun updateSharedIntent(intent: Intent?) {
-        if (intent?.action == Intent.ACTION_SEND && intent.type?.startsWith("audio/") == true) {
-            val uri = intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
-            if (uri != null) {
-                sharedUriState.value = uri
+        if (intent?.action == Intent.ACTION_SEND) {
+            if (intent.type?.startsWith("audio/") == true) {
+                val uri = intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+                if (uri != null) {
+                    sharedUriState.value = uri
+                }
+            } else if (intent.type?.startsWith("text/") == true) {
+                val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+                val url = text?.let { extractUrl(it) }
+                if (url != null) {
+                    sharedTextState.value = url
+                }
             }
         }
+    }
+
+    private fun extractUrl(text: String): String? {
+        val regex = "(https?://\\S+)".toRegex()
+        return regex.find(text)?.value
     }
 }
 

--- a/ringersong/src/main/java/com/RingerSong/free/service/YouTubeMusicPlayerManager.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/service/YouTubeMusicPlayerManager.kt
@@ -26,12 +26,13 @@ class YouTubeMusicPlayerManager @Inject constructor(
      */
     suspend fun playTrack(song: SongEntry): Boolean = withContext(Dispatchers.Main) {
         try {
-            // Extract video ID from uri "youtube:video:VIDEO_ID"
-            val videoId = song.uri.removePrefix("youtube:video:")
-
-            // Construct Deep Link
-            // Tapping this link on Android usually opens YouTube Music if installed
-            val uri = Uri.parse("https://music.youtube.com/watch?v=$videoId")
+            val uri = if (song.uri.startsWith("http")) {
+                Uri.parse(song.uri)
+            } else {
+                // Extract video ID from uri "youtube:video:VIDEO_ID"
+                val videoId = song.uri.removePrefix("youtube:video:")
+                Uri.parse("https://music.youtube.com/watch?v=$videoId")
+            }
 
             Log.d(TAG, "Attempting to launch YouTube Music with URI: $uri")
 

--- a/ringersong/src/main/java/com/RingerSong/free/ui/HomeScreen.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/ui/HomeScreen.kt
@@ -128,6 +128,7 @@ fun HomeScreen(
     onYouTubeSearch: () -> Unit,
     onClearYouTubeSearch: () -> Unit,
     onAddYouTubeTrack: (SpotifyTrack) -> Unit,
+    onAddLink: (String) -> Unit,
     onConnectSpotify: ( (Boolean) -> Unit ) -> Unit,
     userCapabilities: String,
     snackbarHostState: SnackbarHostState
@@ -278,6 +279,7 @@ fun HomeScreen(
                     onSearch = onYouTubeSearch,
                     onClear = onClearYouTubeSearch,
                     onAddTrack = onAddYouTubeTrack,
+                    onAddLink = onAddLink,
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -287,7 +289,10 @@ fun HomeScreen(
                 visible = showContent.value,
                 enter = fadeIn() + slideInVertically(initialOffsetY = { it / 3 })
             ) {
-                AppleMusicPlaceholderSection(modifier = Modifier.fillMaxWidth())
+                AppleMusicSection(
+                    onAddLink = onAddLink,
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -1054,8 +1059,12 @@ private fun YouTubeMusicSection(
     onSearch: () -> Unit,
     onClear: () -> Unit,
     onAddTrack: (SpotifyTrack) -> Unit,
+    onAddLink: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var showPasteLink by remember { mutableStateOf(false) }
+    var link by remember { mutableStateOf("") }
+
     SectionCard(modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -1065,7 +1074,7 @@ private fun YouTubeMusicSection(
                     fontWeight = FontWeight.SemiBold
                 )
                 Text(
-                    text = "Search for tracks on YouTube Music and add them to your progression.",
+                    text = "Search for tracks or paste a YouTube Music link.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -1095,6 +1104,34 @@ private fun YouTubeMusicSection(
                     modifier = Modifier.weight(1f)
                 ) {
                     Text("Clear")
+                }
+            }
+
+            TextButton(
+                onClick = { showPasteLink = !showPasteLink },
+                modifier = Modifier.align(Alignment.End)
+            ) {
+                Text(if (showPasteLink) "Hide Link Input" else "Or Paste Link")
+            }
+
+            if (showPasteLink) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = link,
+                        onValueChange = { link = it },
+                        label = { Text("Paste YouTube Link") },
+                        modifier = Modifier.weight(1f)
+                    )
+                    Button(
+                        onClick = {
+                            onAddLink(link)
+                            link = ""
+                            showPasteLink = false
+                        },
+                        enabled = link.isNotBlank()
+                    ) {
+                        Text("Add")
+                    }
                 }
             }
 
@@ -1181,7 +1218,11 @@ private fun SpotifyResultRow(
 }
 
 @Composable
-private fun AppleMusicPlaceholderSection(modifier: Modifier = Modifier) {
+private fun AppleMusicSection(
+    onAddLink: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var link by remember { mutableStateOf("") }
     SectionCard(modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -1191,21 +1232,31 @@ private fun AppleMusicPlaceholderSection(modifier: Modifier = Modifier) {
                     fontWeight = FontWeight.SemiBold
                 )
                 Text(
-                    text = "Apple Music integration is coming soon.",
+                    text = "Paste a link to an Apple Music track. We'll launch the app to play it.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
+            OutlinedTextField(
+                value = link,
+                onValueChange = { link = it },
+                label = { Text("Paste Apple Music Link") },
+                placeholder = { Text("https://music.apple.com/...") },
+                modifier = Modifier.fillMaxWidth()
+            )
             Button(
-                onClick = { /* No-op or show info dialog */ },
-                enabled = false,
+                onClick = {
+                    onAddLink(link)
+                    link = ""
+                },
+                enabled = link.isNotBlank(),
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(
-                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    containerColor = Color(0xFFFA243C), // Apple Music Red-ish
+                    contentColor = Color.White
                 )
             ) {
-                Text("Coming Soon")
+                Text("Add Track")
             }
         }
     }

--- a/ringersong/src/main/java/com/RingerSong/free/ui/RingerSongApp.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/ui/RingerSongApp.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.launch
 fun RingerSongApp(
     viewModel: RingerViewModel,
     sharedUri: Uri?,
+    sharedText: String?,
     onSharedConsumed: () -> Unit
 ) {
     val navController = rememberNavController()
@@ -40,6 +41,19 @@ fun RingerSongApp(
             viewModel.addSongs(listOf(sharedUri)) { result ->
                 coroutineScope.launch { snackbarHostState.showResult(result) }
                 if (result.addedCount > 0) {
+                    activity?.let { AdServices.showInterstitial(it) }
+                }
+            }
+            onSharedConsumed()
+        }
+    }
+
+    LaunchedEffect(sharedText) {
+        if (sharedText != null) {
+            viewModel.addTrackFromUrl(sharedText) { message ->
+                coroutineScope.launch { snackbarHostState.showSnackbar(message) }
+                // Only show interstitial if success? addTrackFromUrl returns a message.
+                if (!message.startsWith("Error")) {
                     activity?.let { AdServices.showInterstitial(it) }
                 }
             }
@@ -137,6 +151,14 @@ private fun AppNavHost(
                     viewModel.addSpotifyTrack(track) { message ->
                         coroutineScope.launch { snackbarHostState.showSnackbar(message) }
                         activity?.let { AdServices.showInterstitial(it) }
+                    }
+                },
+                onAddLink = { url ->
+                    viewModel.addTrackFromUrl(url) { message ->
+                        coroutineScope.launch { snackbarHostState.showSnackbar(message) }
+                        if (!message.startsWith("Error")) {
+                            activity?.let { AdServices.showInterstitial(it) }
+                        }
                     }
                 },
                 onConnectSpotify = { onResult ->

--- a/ringersong/src/main/java/com/RingerSong/free/viewmodel/RingerViewModel.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/viewmodel/RingerViewModel.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
+import org.jsoup.Jsoup
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -739,5 +740,119 @@ class RingerViewModel @Inject constructor(
             val info = truecallerRepo.getCallerInfo(phoneNumber, "US")
             onComplete(info)
         }
+    }
+
+    fun addTrackFromUrl(url: String, onResult: (String) -> Unit) {
+        val uid = auth?.currentUser?.uid ?: run {
+            onResult("Error: Please sign in to add songs")
+            return
+        }
+        val safeDb = db ?: run {
+            onResult("Error: Database unavailable")
+            return
+        }
+
+        viewModelScope.launch {
+            val cleanUrl = url.trim()
+            var source = SongSource.LOCAL
+            var uri = cleanUrl
+            var title = "Unknown Track"
+            var spotifyId: String? = null
+
+            // Detect Source
+            if (cleanUrl.contains("music.apple.com")) {
+                source = SongSource.APPLE_MUSIC
+            } else if (cleanUrl.contains("youtube.com") || cleanUrl.contains("youtu.be")) {
+                source = SongSource.YOUTUBE_MUSIC
+                // Extract video ID if possible, but keeping full URL is often fine for intent handling
+                // Ideally normalize to youtube:video:ID for internal consistency if possible
+                val videoId = extractYouTubeId(cleanUrl)
+                if (videoId != null) {
+                    uri = "youtube:video:$videoId"
+                }
+            } else if (cleanUrl.contains("open.spotify.com/track")) {
+                source = SongSource.SPOTIFY
+                // Extract ID: open.spotify.com/track/ID?si=...
+                val id = cleanUrl.substringAfter("track/").substringBefore("?")
+                spotifyId = id
+                uri = "spotify:track:$id"
+            } else {
+                onResult("Error: Unsupported URL service")
+                return@launch
+            }
+
+            // Fetch Metadata (Title) via Jsoup
+            withContext(Dispatchers.IO) {
+                try {
+                    val doc = Jsoup.connect(cleanUrl)
+                        .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
+                        .timeout(10000)
+                        .get()
+                    val pageTitle = doc.title()
+                    // Cleanup title (e.g. "Song Name - Artist - Apple Music" -> "Song Name - Artist")
+                    title = pageTitle.replace(" - Apple Music", "")
+                        .replace(" - YouTube Music", "")
+                        .replace(" - YouTube", "")
+                        .replace(" | Spotify", "")
+                } catch (e: Exception) {
+                    // Fallback to existing title or simplified
+                    title = when(source) {
+                        SongSource.APPLE_MUSIC -> "Apple Music Track"
+                        SongSource.YOUTUBE_MUSIC -> "YouTube Music Track"
+                        SongSource.SPOTIFY -> "Spotify Track"
+                        else -> "Web Track"
+                    }
+                }
+            }
+
+            val songId = UUID.randomUUID().toString()
+            val songEntry = SongEntry(
+                id = songId,
+                title = title,
+                uri = uri,
+                source = source,
+                durationMs = 0L, // Unknown
+                addedAt = System.currentTimeMillis()
+            )
+
+            // Update local state
+            withContext(Dispatchers.IO) {
+                store.update { current ->
+                    val updatedSongs = current.songs + songEntry
+                    val updatedOrder = current.songOrder + songEntry.id
+                    current.copy(songs = updatedSongs, songOrder = updatedOrder)
+                }
+            }
+
+            // Sync to Firestore
+            val trackData = hashMapOf(
+                "uri" to uri,
+                "source" to source.name,
+                "title" to title,
+                "artist" to "Unknown", // Metadata scraping usually combines them in title
+                "durationMs" to 0L,
+                "addedAt" to com.google.firebase.Timestamp.now(),
+                "downloaded" to false
+            )
+            if (spotifyId != null) {
+                trackData["spotifyId"] = spotifyId
+                trackData["spotifyUri"] = uri
+            }
+
+            safeDb.collection("users").document(uid).collection("ringer_playlist")
+                .add(trackData)
+                .addOnSuccessListener {
+                    onResult("Added $title")
+                }
+                .addOnFailureListener { e ->
+                     onResult("Error syncing: ${e.message}")
+                }
+        }
+    }
+
+    private fun extractYouTubeId(url: String): String? {
+        // Simple regex for video ID
+        val regex = "(?<=v=|/videos/|embed\\/|youtu.be\\/|\\/v\\/|\\/e\\/|watch\\?v=|&v=)([^#\\&\\?]*).*".toRegex()
+        return regex.find(url)?.groupValues?.get(1)
     }
 }


### PR DESCRIPTION
This PR addresses issues with RingerSong's music source integration by shifting focus from "importing" (which relied on broken RapidAPI) to "streaming" via deep links and App Remote.

Key changes:
1.  **Apple Music Support**: Implemented "Add from Link" feature. Users can share a song from Apple Music or paste a link. The app scrapes the title using Jsoup and saves it. Playback launches the Apple Music app via deep link.
2.  **YouTube Music Fixes**: Added "Paste Link" fallback for YouTube Music to bypass potential RapidAPI search failures. Hardened `YouTubeMusicPlayerManager` to handle raw HTTP links correctly.
3.  **Shared Intents**: `MainActivity` now accepts `text/plain` shared content, extracting URLs to automatically trigger the "Add Song" flow.
4.  **UI Updates**: Replaced "Coming Soon" for Apple Music with a functional input section. Added "Paste Link" option to YouTube Music section.

This ensures users can use their paid memberships (Apple/YouTube Music) as ringers by launching the respective apps, while Spotify continues to use App Remote for background playback. The default ringer is silenced via `CallScreeningService` (permission prompted in UI).

---
*PR created automatically by Jules for task [11320478127816449820](https://jules.google.com/task/11320478127816449820) started by @DamienLove*