### PR TITLE
Fix Unified Inbox filters and rename Extensions Store

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/BeaconInboxActivity.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/BeaconInboxActivity.kt
@@ -458,6 +458,7 @@ class BeaconInboxActivity : ComponentActivity() {
                                             }
                                         } else {
                                             SmsInboxScreen(
+                                            isUnifiedMode = state.settings.mergedExperienceEnabled,
                                             threads = displayedThreads,
                                             archivedThreads = displayedArchived,
                                             onOpenThread = { thread ->

--- a/androidApp/src/main/java/com/pulselink/ui/screens/SmsInboxScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/SmsInboxScreen.kt
@@ -1315,10 +1315,8 @@ fun TabsRow(
                 onFilterChange(target)
             }
         }
-        if (!isUnifiedMode) {
-            TabText(label = "All", selected = filter == InboxFilter.ALL, theme = theme) {
-                toggleFilter(InboxFilter.ALL)
-            }
+        TabText(label = "All", selected = filter == InboxFilter.ALL, theme = theme) {
+            toggleFilter(InboxFilter.ALL)
         }
         if (isUnifiedMode) {
             TabText(label = "2-step", selected = filter == InboxFilter.OTP, theme = theme) {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1933,12 +1933,12 @@ const Sidebar = memo(({
         <button
           className={`nav-item ${activePanel === 'extensions' ? 'active' : ''}`}
           onClick={() => setActivePanel('extensions')}
-          title="Features"
-          aria-label="Features"
+          title="Extensions"
+          aria-label="Extensions"
           aria-current={activePanel === 'extensions' ? 'page' : undefined}
         >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
-          <span>Features</span>
+          <ExtensionIcon />
+          <span>Extensions</span>
           <span className="badge-new">NEW</span>
         </button>
         <button
@@ -4836,7 +4836,7 @@ function App() {
           {activePanel === 'extensions' && (
             <div className="pulselink-panel">
               <div className="panel-header">
-                <h3>Features</h3>
+                <h3>Extensions Store</h3>
                 <p>Enhance your PulseLink experience with powerful add-ons.</p>
               </div>
 

--- a/web/tests/comprehensive_verification.spec.js
+++ b/web/tests/comprehensive_verification.spec.js
@@ -52,13 +52,13 @@ test.describe('Comprehensive Feature Verification', () => {
     expect(src).toContain('placehold.co/100x100.png');
   });
 
-  test('should verify Features (Extensions) functionality', async ({ page }) => {
-    // Navigate to Features (Extensions)
-    // The button title might be "Features" or "Extensions" depending on state, but Sidebar usually renders it as "Features"
-    const btn = page.locator('.nav-item[title="Features"]');
+  test('should verify Extensions functionality', async ({ page }) => {
+    // Navigate to Extensions
+    // The button title is "Extensions"
+    const btn = page.locator('.nav-item[title="Extensions"]');
     await btn.click();
 
-    await expect(page.getByRole('heading', { name: 'Features', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Extensions Store', exact: true })).toBeVisible();
 
     // Check for "Crash Detection" card presence
     const crashCard = page.locator('.home-card h3', { hasText: 'Crash Detection' });


### PR DESCRIPTION
This PR addresses reported issues regarding missing filters in the Unified Inbox and confusion about the missing "Extension Store" in the web app.

**Changes:**
1.  **Web App (`web/src/App.jsx`):**
    - Renamed "Features" sidebar item to "Extensions".
    - Renamed "Features" page header to "Extensions Store".
    - Updated `web/tests/comprehensive_verification.spec.js` to match the new labeling.

2.  **Android App (`androidApp/src/main/java/com/pulselink/ui/screens/SmsInboxScreen.kt`):**
    - Modified `TabsRow` to always render the "All" filter tab. Previously, it was hidden in Unified Mode, leading to user confusion about the missing "sms" filter.

3.  **Android App (`androidApp/src/main/java/com/pulselink/ui/BeaconInboxActivity.kt`):**
    - Updated `SmsInboxScreen` instantiation to pass `isUnifiedMode = state.settings.mergedExperienceEnabled`. This ensures that if a user opens the standalone Beacon activity (e.g., via a legacy shortcut or intent), they still see the Unified filters (2-step, Trusted, etc.) if they have opted into the Unified Experience.

**Issues Fixed:**
- #365: Unified navigation missing filters (sms, 2-step, etc.)
- #368: Extension store missing from web app (renamed/clarified)

---
*PR created automatically by Jules for task [15335818273835790254](https://jules.google.com/task/15335818273835790254) started by @DamienLove*