### PR TITLE
🎨 Palette: Dynamic Avatar Contrast & Loading A11y

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-28 - Image Load Error Fallbacks
 **Learning:** User-provided URLs for avatars often break (404s), resulting in ugly browser-default broken image icons that degrade perceived app quality. Relying solely on "if URL exists" logic is insufficient.
 **Action:** Implemented a `useState` + `onError` handler pattern in the `Avatar` component to detect load failures and automatically revert to the deterministic initial fallback, maintaining UI elegance even with bad data.
+
+## 2024-05-29 - Dynamic Avatar Contrast
+**Learning:** Randomly generated background colors for avatars (based on name hash) frequently result in poor contrast ratios with static text color (white), making initials unreadable for names like "Alice".
+**Action:** Implemented a YIQ contrast formula helper (`getContrastColor`) to dynamically calculate the optimal text color (black or white) based on the background's luminance.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -147,6 +147,16 @@ const stringToColor = (str) => {
   return '#' + '00000'.substring(0, 6 - c.length) + c;
 };
 
+// Palette: Ensure text is readable against generated background
+const getContrastColor = (hex) => {
+  if (!hex) return '#fff';
+  const r = parseInt(hex.substr(1, 2), 16);
+  const g = parseInt(hex.substr(3, 2), 16);
+  const b = parseInt(hex.substr(5, 2), 16);
+  const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+  return (yiq >= 128) ? '#000000' : '#FFFFFF';
+};
+
 const Avatar = memo(({ name, url, size = 40, style, className = "thread-avatar" }) => {
   const [imgError, setImgError] = useState(false);
 
@@ -159,8 +169,9 @@ const Avatar = memo(({ name, url, size = 40, style, className = "thread-avatar" 
   }
   const initials = (name || '?').slice(0, 2).toUpperCase();
   const bg = stringToColor(name || '?');
+  const textColor = getContrastColor(bg);
   return (
-    <div className={className} style={{ width: size, height: size, background: bg, ...style, display: 'grid', placeItems: 'center', color: '#fff', fontWeight: '700' }}>
+    <div className={className} style={{ width: size, height: size, background: bg, ...style, display: 'grid', placeItems: 'center', color: textColor, fontWeight: '700' }}>
       {initials}
     </div>
   );
@@ -2057,7 +2068,9 @@ const Sidebar = memo(({
                  </div>
             )}
             {isLoadingThreads ? (
-               Array.from({ length: 5 }).map((_, i) => <ThreadSkeleton key={i} />)
+              <div role="status" aria-label="Loading conversations">
+                {Array.from({ length: 5 }).map((_, i) => <ThreadSkeleton key={i} />)}
+              </div>
             ) : filteredThreads.length === 0 ? (
               <div className="sidebar-placeholder">
                 <div className="sidebar-tip">

--- a/web/tests/palette_ux.spec.js
+++ b/web/tests/palette_ux.spec.js
@@ -60,4 +60,73 @@ test.describe('Palette UX Enhancements', () => {
     await expect(hint).toHaveText('/');
     await expect(hint).toHaveAttribute('aria-hidden', 'true');
   });
+
+  test('Avatar text should have sufficient contrast', async ({ page }) => {
+    // 1. Check "Alice" in Contacts (Expect Black text on Light BG)
+    await page.locator('.nav-item[title="Contacts"]').click();
+
+    // Find Alice's row
+    const aliceRow = page.locator('.contact-row', { hasText: 'Alice' });
+    await expect(aliceRow).toBeVisible();
+
+    // In DeviceContactItem, Avatar is not explicitly rendered, but wait...
+    // DeviceContactItem source:
+    /*
+    const DeviceContactItem = memo(({ contact }) => {
+      // ...
+      return (
+        <div className="contact-row contact-row--stacked">
+          { // No Avatar component here! It just shows text. }
+          <div className="contact-main">
+            <div className="contact-name">{contact.displayName || 'Unnamed contact'}</div>
+    */
+    // Ah! DeviceContactItem does NOT use Avatar component in the current code I read!
+    // Let me check App.jsx again.
+
+    // Sidebar ThreadItem USES Avatar.
+    // ThreadItem: <Avatar name={name} />
+
+    // "Test Contact" (thread) is in mock data.
+    // Name: Test Contact, BG: #9A3E92, Text: #FFFFFF (White)
+
+    // I need a thread with a name that produces Black text.
+    // "Alice" -> Black.
+    // Is there a thread for Alice?
+
+    // Mock data:
+    // setLegacyThreads([{ id: 'thread_1', address: '+15559998888', display_name: 'Test Contact', ... }]);
+
+    // I can modify the mock data in the test via window.debugSetLegacyThreads if I'm in DEV mode.
+    // But playwright runs against built app? Or dev server?
+    // Usually dev server.
+
+    // Let's try to verify "Test Contact" (White text) first.
+    await page.locator('.nav-item[title="Beacon"]').click();
+    const threadItem = page.locator('.thread-item', { hasText: 'Test Contact' });
+    await expect(threadItem).toBeVisible();
+
+    const avatar = threadItem.locator('.thread-avatar');
+    await expect(avatar).toHaveCSS('color', 'rgb(255, 255, 255)');
+
+    // Now let's try to inject a thread for "Alice" (Black text)
+    await page.evaluate(() => {
+        if (window.debugSetLegacyThreads) {
+            window.debugSetLegacyThreads([{
+                id: 'thread_alice',
+                address: '+15550001111',
+                display_name: 'Alice',
+                date: Date.now(),
+                snippet: 'Hello',
+                pinned: false,
+                archived: false
+            }]);
+        }
+    });
+
+    const aliceItem = page.locator('.thread-item', { hasText: 'Alice' });
+    await expect(aliceItem).toBeVisible();
+    const aliceAvatar = aliceItem.locator('.thread-avatar');
+    // Alice BG is #C6A660 -> Black text
+    await expect(aliceAvatar).toHaveCSS('color', 'rgb(0, 0, 0)');
+  });
 });


### PR DESCRIPTION
This PR improves the accessibility of the UI by ensuring that user avatars always have sufficient text contrast. Previously, the white text could be unreadable on light backgrounds generated by the name hash (e.g., "Alice" -> light tan). A new `getContrastColor` helper now dynamically selects black or white text.

Additionally, the sidebar loading state (skeletons) has been updated with `role="status"` and `aria-label` to announce the loading state to screen readers.

A new test case has been added to `web/tests/palette_ux.spec.js` to verify the contrast logic.

---
*PR created automatically by Jules for task [14772619958784709191](https://jules.google.com/task/14772619958784709191) started by @DamienLove*