### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limit to isValidUrl

### DIFF
--- a/functions/src/security.test.ts
+++ b/functions/src/security.test.ts
@@ -1,4 +1,4 @@
-import {escapeHtml} from "./security";
+import {escapeHtml, isValidUrl} from "./security";
 
 describe("escapeHtml", () => {
   describe("Basic HTML escaping", () => {
@@ -209,5 +209,37 @@ describe("escapeHtml", () => {
       const input = "line1\r\nline2";
       expect(escapeHtml(input)).toBe("line1\r\nline2");
     });
+  });
+});
+
+describe("isValidUrl", () => {
+  it("should return true for valid http URLs", () => {
+    expect(isValidUrl("http://example.com")).toBe(true);
+  });
+
+  it("should return true for valid https URLs", () => {
+    expect(isValidUrl("https://example.com")).toBe(true);
+  });
+
+  it("should return false for invalid schemes (ftp)", () => {
+    expect(isValidUrl("ftp://example.com")).toBe(false);
+  });
+
+  it("should return false for javascript: scheme", () => {
+    expect(isValidUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("should return false for malformed URLs", () => {
+    expect(isValidUrl("not-a-url")).toBe(false);
+  });
+
+  it("should return false for excessively long URLs", () => {
+    const longUrl = "https://example.com/" + "a".repeat(2050);
+    expect(isValidUrl(longUrl)).toBe(false);
+  });
+
+  it("should return true for long but valid URLs under the limit", () => {
+    const longUrl = "https://example.com/" + "a".repeat(100);
+    expect(isValidUrl(longUrl)).toBe(true);
   });
 });

--- a/functions/src/security.ts
+++ b/functions/src/security.ts
@@ -54,6 +54,10 @@ export function sanitizeScalar(unsafe: string | null | undefined): string {
  * @return {boolean} True if the string is a valid http/https URL.
  */
 export function isValidUrl(url: string): boolean {
+  // Sentinel: Prevent Denial of Service (DoS) via excessively long URLs
+  if (url.length > 2048) {
+    return false;
+  }
   try {
     const parsed = new URL(url);
     return parsed.protocol === "http:" || parsed.protocol === "https:";


### PR DESCRIPTION
This PR adds a length check to the `isValidUrl` security helper function to prevent potential Denial of Service (DoS) attacks via excessively long URL inputs. It enforces a maximum length of 2048 characters, which is a standard limit for URLs. Tests have been added to verify this behavior.

---
*PR created automatically by Jules for task [14538199237285744113](https://jules.google.com/task/14538199237285744113) started by @DamienLove*