### PR TITLE
Fix SMS login for offline users

### DIFF
--- a/androidApp/src/main/java/com/pulselink/auth/AuthState.kt
+++ b/androidApp/src/main/java/com/pulselink/auth/AuthState.kt
@@ -6,4 +6,5 @@ sealed interface AuthState {
     object Loading : AuthState
     object Unauthenticated : AuthState
     data class Authenticated(val user: FirebaseUser) : AuthState
+    object AuthenticatedOffline : AuthState
 }

--- a/androidApp/src/main/java/com/pulselink/auth/FirebaseAuthManager.kt
+++ b/androidApp/src/main/java/com/pulselink/auth/FirebaseAuthManager.kt
@@ -25,6 +25,8 @@ class FirebaseAuthManager @Inject constructor(
     private val _authState = MutableStateFlow<AuthState>(AuthState.Loading)
     val authState: StateFlow<AuthState> = _authState.asStateFlow()
 
+    private var isOfflineMode = false
+
     private val authListener = FirebaseAuth.AuthStateListener { firebaseAuth ->
         updateAuthState(firebaseAuth.currentUser)
     }
@@ -35,6 +37,7 @@ class FirebaseAuthManager @Inject constructor(
     }
 
     private fun updateAuthState(user: FirebaseUser?) {
+        if (isOfflineMode) return
         Log.d(TAG, "Auth state updated user=${user?.uid ?: "null"} anon=${user?.isAnonymous}")
         _authState.value = user?.let { AuthState.Authenticated(it) } ?: AuthState.Unauthenticated
     }
@@ -53,11 +56,17 @@ class FirebaseAuthManager @Inject constructor(
         }
     }
 
-    suspend fun signInSmsOnly(): Result<FirebaseUser> {
+    suspend fun signInSmsOnly(): Result<Unit> {
         return runCatching {
-            auth.signInAnonymously().await().user ?: error("Anonymous sign-in returned no user")
-        }.onFailure { error ->
-            Log.w(TAG, "SMS-only sign-in failed", error)
+            try {
+                auth.signInAnonymously().await()
+                isOfflineMode = false
+                // updateAuthState will be called by listener
+            } catch (e: Exception) {
+                Log.w(TAG, "Anonymous sign-in failed, falling back to offline mode", e)
+                isOfflineMode = true
+                _authState.value = AuthState.AuthenticatedOffline
+            }
         }
     }
 
@@ -148,7 +157,13 @@ class FirebaseAuthManager @Inject constructor(
     }
 
     suspend fun signOut(): Result<Unit> {
-        return runCatching { auth.signOut() }
+        return runCatching {
+            isOfflineMode = false
+            auth.signOut()
+            if (_authState.value == AuthState.AuthenticatedOffline) {
+                _authState.value = AuthState.Unauthenticated
+            }
+        }
     }
 
     fun currentUser(): FirebaseUser? = auth.currentUser

--- a/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
@@ -253,8 +253,8 @@ class MainActivity : AppCompatActivity() {
                 val navController = rememberNavController()
 
                 LaunchedEffect(authState) {
-                    val authenticated = authState as? AuthState.Authenticated
-                    if (authenticated != null && subscriptionManager.subscriptionState.value.available) {
+                    val isAuthenticated = authState is AuthState.Authenticated || authState is AuthState.AuthenticatedOffline
+                    if (isAuthenticated && subscriptionManager.subscriptionState.value.available) {
                         subscriptionManager.refreshPremiumStatus()
                     }
                 }
@@ -876,7 +876,7 @@ class MainActivity : AppCompatActivity() {
                         }
 
                         NavHost(navController = navController, startDestination = startDestination) {
-                    val premiumBranding = state.settings.premiumUnlocked ||     
+                    val premiumBranding = state.settings.premiumUnlocked ||
                         BuildConfig.PREMIUM_FEATURES ||
                         state.isProUser
                     val proLikeUser = BuildConfig.PRO_FEATURES || state.settings.proUnlocked || state.settings.premiumUnlocked
@@ -899,16 +899,15 @@ class MainActivity : AppCompatActivity() {
                         LaunchedEffect(authState, state.onboardingComplete) {
                             if (authState is AuthState.Loading) return@LaunchedEffect
                             delay(1200)
-                            val destination = when (val auth = authState) {
-                                is AuthState.Authenticated -> {
-                                    val user = auth.user
-                                    if (state.onboardingComplete) {
-                                        if (unifiedModeActive) "unified_inbox" else "home"
-                                    } else {
-                                        "onboarding_intro"
-                                    }
+                            val isAuthenticated = authState is AuthState.Authenticated || authState is AuthState.AuthenticatedOffline
+                            val destination = if (isAuthenticated) {
+                                if (state.onboardingComplete) {
+                                    if (unifiedModeActive) "unified_inbox" else "home"
+                                } else {
+                                    "onboarding_intro"
                                 }
-                                else -> "login"
+                            } else {
+                                "login"
                             }
                             navController.navigate(destination) {
                                 popUpTo(0) { inclusive = true }
@@ -927,8 +926,8 @@ class MainActivity : AppCompatActivity() {
                             }
                             map.toMap()
                         }
-                        
-                        val isSmsOnlyUser = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true
+
+                        val isSmsOnlyUser = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true || authState is AuthState.AuthenticatedOffline
                         UnifiedHomeScreen(
                             state = state,
                             onDismissAssistantShortcuts = viewModel::dismissAssistantHint,
@@ -1077,11 +1076,13 @@ class MainActivity : AppCompatActivity() {
                             onMessageConsumed = loginViewModel::clearTransientMessages,
                             useProBranding = false
                         )
-                        val initialAnonymous = rememberSaveable { (authState as? AuthState.Authenticated)?.user?.isAnonymous == true }
+                        val isAnonymous = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true || authState is AuthState.AuthenticatedOffline
+                        val initialAnonymous = rememberSaveable { isAnonymous }
                         LaunchedEffect(authState, state.onboardingComplete) {
-                            val authenticated = authState as? AuthState.Authenticated
-                            if (authenticated != null) {
-                                if (!authenticated.user.isAnonymous || !initialAnonymous) {
+                            val isAuthenticated = authState is AuthState.Authenticated || authState is AuthState.AuthenticatedOffline
+                            val currentAnonymous = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true || authState is AuthState.AuthenticatedOffline
+                            if (isAuthenticated) {
+                                if (!currentAnonymous || !initialAnonymous) {
                                     val destination = if (state.onboardingComplete) "home" else "onboarding_intro"
                                     navController.navigate(destination) {
                                         popUpTo(0) { inclusive = true }
@@ -1294,7 +1295,7 @@ class MainActivity : AppCompatActivity() {
                         )
                     }
                     composable("home") {
-                        val isSmsOnlyUser = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true
+                        val isSmsOnlyUser = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true || authState is AuthState.AuthenticatedOffline
                         HomeScreen(
                             state = state,
                             onDismissAssistantShortcuts = viewModel::dismissAssistantHint,
@@ -1659,7 +1660,7 @@ class MainActivity : AppCompatActivity() {
                             customVibration.takeIf { state.settings.checkInProfile.vibrationPatternKey == VibrationPatterns.CUSTOM_KEY }
                                 ?: VibrationPatterns.alertOption(state.settings.checkInProfile.vibrationPatternKey)
                             ).label
-                        val isSmsOnlyUser = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true
+                        val isSmsOnlyUser = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true || authState is AuthState.AuthenticatedOffline
                         SettingsScreen(
                             settings = state.settings,
                             hasDndAccess = hasDndAccess,

--- a/androidApp/src/main/java/com/pulselink/ui/state/LoginViewModel.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/state/LoginViewModel.kt
@@ -35,7 +35,7 @@ class LoginViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             authManager.authState.collect { authState ->
-                val isAnon = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true
+                val isAnon = (authState as? AuthState.Authenticated)?.user?.isAnonymous == true || authState is AuthState.AuthenticatedOffline
                 _uiState.update {
                     it.copy(
                         isAnonymousUser = isAnon,


### PR DESCRIPTION
Fixes issues where SMS login would fail or do nothing when the device is offline.
- Added `AuthenticatedOffline` to `AuthState`.
- Updated `FirebaseAuthManager` to catch sign-in exceptions and enter offline mode.
- Updated UI logic to treat offline mode as a valid session for navigation.

---
*PR created automatically by Jules for task [15631478436201480760](https://jules.google.com/task/15631478436201480760) started by @DamienLove*