### PR TITLE
Fix Android widget redundancy, bug report URL, and README donation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,16 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 
 ## 💖 Support the Project
 
-PulseLink is built on the belief that personal safety is a right, not a privilege. Your support funds our server infrastructure (Firebase, SMS gateways) and continued development.
-
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-❤_GitHub_Sponsors-ea4aaa?logo=github)](https://github.com/sponsors/DamienLove)
 [![Ko‑fi](https://img.shields.io/badge/Buy_me_a_coffee-Ko%E2%80%91fi-29abe0?logo=kofi)](https://ko-fi.com/DamienLove)
+
+If PulseLink helps you or someone you care about, please consider supporting development. Your contributions fund:
+
+- App Store fees and infrastructure (build minutes, test devices)
+- Accessibility and safety research
+- iOS development to reach more users
+
+Sponsor or tip: GitHub Sponsors · Ko‑fi · PayPal (see badges above)
 
 ---
 

--- a/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
@@ -1521,6 +1521,8 @@ class MainViewModel @Inject constructor(
         // Direct to GitHub issue form so users land on the correct bug report page.
         return Uri.parse(BUG_REPORT_PAGE_URL)
             .buildUpon()
+            .appendQueryParameter("template", "bug_report.md")
+            .appendQueryParameter("labels", "bug")
             .appendQueryParameter("title", subjectSuffix)
             .appendQueryParameter("body", formattedBody)
             .build()

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -7,27 +7,6 @@
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
 
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
This PR addresses three issues:
1. Fixes #76 by removing redundant widget declarations in the Pro flavor manifest to rely on manifest merging.
2. Fixes #77 by updating the bug report URL to include `template=bug_report.md` and `labels=bug` parameters, ensuring correct issue metadata.
3. Fixes #70 by updating the README support section with the approved donation messaging.

---
*PR created automatically by Jules for task [8135183449442471182](https://jules.google.com/task/8135183449442471182) started by @DamienLove*