### PR TITLE
🎨 Palette: Auto-focus message composer on desktop

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-28 - Image Load Error Fallbacks
 **Learning:** User-provided URLs for avatars often break (404s), resulting in ugly browser-default broken image icons that degrade perceived app quality. Relying solely on "if URL exists" logic is insufficient.
 **Action:** Implemented a `useState` + `onError` handler pattern in the `Avatar` component to detect load failures and automatically revert to the deterministic initial fallback, maintaining UI elegance even with bad data.
+
+## 2024-05-29 - Auto-focus for Thread Switching
+**Learning:** Users switching between chat threads expect immediate keyboard readiness. Forcing a click to focus the textarea creates friction. However, on mobile, auto-focus triggers the virtual keyboard, obscuring the view.
+**Action:** Implemented logic to auto-focus the composer (or "To" field) when the selected thread changes, but strictly guarded by `window.innerWidth > 768` check to protect the mobile experience.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -720,6 +720,7 @@ const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeL
   const [status, setStatus] = useState('');
   const [isSending, setIsSending] = useState(false);
   const textareaRef = useRef(null);
+  const addressInputRef = useRef(null);
 
   useLayoutEffect(() => {
     const el = textareaRef.current;
@@ -739,6 +740,18 @@ const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeL
     }
     setBody('');
     setStatus('');
+
+    // Palette: Auto-focus input on desktop to reduce friction
+    if (typeof window !== 'undefined' && window.innerWidth > 768) {
+      // Small timeout to allow for layout updates/transitions
+      setTimeout(() => {
+        if (selectedThread) {
+          textareaRef.current?.focus();
+        } else {
+          addressInputRef.current?.focus();
+        }
+      }, 100);
+    }
   }, [selectedThread]);
 
   const handleSendMessage = async () => {
@@ -794,6 +807,7 @@ const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeL
         <label className="composer-label" htmlFor="compose-address">To<RequiredIndicator /></label>
         <input
           id="compose-address"
+          ref={addressInputRef}
           className="composer-input"
           type="tel"
           placeholder="Phone number"

--- a/web/tests/palette_ux.spec.js
+++ b/web/tests/palette_ux.spec.js
@@ -60,4 +60,23 @@ test.describe('Palette UX Enhancements', () => {
     await expect(hint).toHaveText('/');
     await expect(hint).toHaveAttribute('aria-hidden', 'true');
   });
+
+  test('MessageComposer should auto-focus inputs on desktop', async ({ page }) => {
+    // Ensure desktop viewport
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    // Navigate to Beacon
+    await page.locator('.nav-item[title="Beacon"]').click();
+
+    // Expect "To" input to be focused immediately after navigation
+    await expect(page.locator('#compose-address')).toBeFocused({ timeout: 5000 });
+
+    // Select a thread (assuming mock data has threads)
+    const firstThread = page.locator('.thread-item').first();
+    await firstThread.waitFor();
+    await firstThread.click();
+
+    // Expect textarea to be focused
+    await expect(page.locator('.composer-textarea')).toBeFocused({ timeout: 5000 });
+  });
 });


### PR DESCRIPTION
💡 What: Added auto-focus logic to `MessageComposer` in the web app.
🎯 Why: Reduces friction when switching between conversations by making the input ready to type immediately.
📸 Before/After: (Behavioral change) Before, user had to click to type after selecting a thread. Now, focus is automatic on desktop.
♿ Accessibility: Improves keyboard navigation flow for desktop users. Carefully excluded on mobile to prevent virtual keyboard intrusion.

---
*PR created automatically by Jules for task [14185204168036103890](https://jules.google.com/task/14185204168036103890) started by @DamienLove*