### PR TITLE
Enhance iOS builds: Add Check-In to PulseLink, Pro UI to Beacon

### DIFF
--- a/iosApp/BeaconiOS/ContentView.swift
+++ b/iosApp/BeaconiOS/ContentView.swift
@@ -231,6 +231,18 @@ private struct BeaconTab: View {
                 )
             }
             .navigationTitle(isPro && filter == .inbox ? "\(filter.title) Pro" : filter.title)
+            .toolbar {
+                if isPro && filter == .inbox {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Text("PRO")
+                            .font(.caption2.bold())
+                            .padding(4)
+                            .background(RelayColors.accent)
+                            .foregroundColor(.white)
+                            .cornerRadius(4)
+                    }
+                }
+            }
             .sheet(isPresented: $showPinSheet) {
                 NavigationStack {
                     VStack(spacing: 20) {

--- a/iosApp/PulseLinkiOS/AlertRelayViewModel.swift
+++ b/iosApp/PulseLinkiOS/AlertRelayViewModel.swift
@@ -150,6 +150,36 @@ final class AlertRelayViewModel: ObservableObject {
         }
     }
 
+    func sendCheckIn() async {
+        statusText = "Sending check-in..."
+        let location = await emergencyLocationService.getCurrentLocation()
+
+        let recipients = trustedContacts.map { contact in
+            AlertRecipient(phoneNumber: contact.address, pushToken: nil, email: nil)
+        }
+
+        guard !recipients.isEmpty else {
+             statusText = "No trusted contacts to check in with."
+             return
+        }
+
+        let request = AlertRequest(
+            message: "I'm checking in. I am safe.",
+            severity: AlertSeverity.checkIn,
+            recipients: recipients,
+            senderId: nil,
+            location: location,
+            metadata: ["type": "check_in"]
+        )
+
+        do {
+            let response = try await client.sendAlert(request: request)
+            statusText = "Check-in sent: \(response.status)"
+        } catch {
+            statusText = "Check-in failed: \(error.localizedDescription)"
+        }
+    }
+
     // MARK: - Emergency flow
 
     func startEmergencyCountdown(seconds: Int = 5) {

--- a/iosApp/PulseLinkiOS/ContentView.swift
+++ b/iosApp/PulseLinkiOS/ContentView.swift
@@ -90,6 +90,7 @@ private struct HomeTab: View {
                             .clipShape(Capsule())
                     }
 
+                    checkInCard
                     relayCard
                     overrideCard
                     activityCard
@@ -186,6 +187,30 @@ private struct HomeTab: View {
                         .foregroundStyle(.secondary)
                 }
             }
+        }
+    }
+
+    private var checkInCard: some View {
+        Card {
+            HStack {
+                Text("Check In")
+                    .font(.headline)
+                Spacer()
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
+            Button {
+                Task { await viewModel.sendCheckIn() }
+            } label: {
+                Label("I'm OK", systemImage: "checkmark")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.green)
+
+            Text("Sends a check-in alert to your trusted contacts.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/iosApp/PulseLinkiOS/EmergencyLocationService.swift
+++ b/iosApp/PulseLinkiOS/EmergencyLocationService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Shared
 #if canImport(FirebaseFirestore)
 import FirebaseFirestore
 #endif
@@ -46,4 +47,9 @@ final class EmergencyLocationService {
     #else
     func recordEmergencyLocation(message: String?) async -> Bool { false }
     #endif
+
+    func getCurrentLocation() async -> GeoPoint? {
+        guard let location = await EmergencyLocationProvider.shared.requestLocation() else { return nil }
+        return GeoPoint(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude, accuracyMeters: location.horizontalAccuracy)
+    }
 }


### PR DESCRIPTION
This PR addresses the user request to bring iOS builds closer to Android functionality and look.
It introduces the "Check In" feature for PulseLink iOS, which sends a safety alert to trusted contacts, bridging a key functional gap.
It also enhances the Beacon iOS UI by explicitly indicating the "Pro" status in the toolbar, ensuring parity with the PulseLink iOS Pro indicator.
The changes rely on the shared Kotlin Multiplatform logic for networking and types, ensuring protocol compatibility.

---
*PR created automatically by Jules for task [14266661538134468278](https://jules.google.com/task/14266661538134468278) started by @DamienLove*