### PR TITLE
Fix redundant widget declarations in Android Pro manifest

### DIFF
--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -7,27 +7,6 @@
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
 
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Removed redundant declarations of `PulseLinkWidgetProvider`, `PulseLinkWidgetActionReceiver`, and `PulseLinkWidgetService` from `androidApp/src/pro/AndroidManifest.xml`. These components are already defined in `androidApp/src/main/AndroidManifest.xml` and should be inherited by the Pro flavor without explicit re-declaration. This fixes potential manifest merge conflicts and ensures the widget is correctly included in the Pro build. Verified the fix by running the `processProDebugManifest` Gradle task and checking the merged manifest output.

---
*PR created automatically by Jules for task [5506964206254767734](https://jules.google.com/task/5506964206254767734) started by @DamienLove*