### PR TITLE
Fix RingerSong stability and add Tidal/Universal link support

### DIFF
--- a/ringersong/src/main/java/com/RingerSong/free/data/Models.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/data/Models.kt
@@ -26,7 +26,8 @@ enum class SongSource {
     SPOTIFY,
     YOUTUBE_MUSIC,
     LOCAL,
-    APPLE_MUSIC // Added for future support
+    APPLE_MUSIC,
+    TIDAL
 }
 
 @Serializable

--- a/ringersong/src/main/java/com/RingerSong/free/receiver/CallStateReceiver.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/receiver/CallStateReceiver.kt
@@ -31,6 +31,16 @@ class CallStateReceiver : BroadcastReceiver() {
         Log.d(TAG, "onReceive: action=${intent.action}")
         if (intent.action != TelephonyManager.ACTION_PHONE_STATE_CHANGED) return
 
+        // If we hold the Call Screening role, the RingerCallScreeningService will handle everything.
+        // We should skip execution here to avoid double-handling (silencing fights, double playback start).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val roleManager = context.getSystemService(Context.ROLE_SERVICE) as? android.app.role.RoleManager
+            if (roleManager != null && roleManager.isRoleHeld(android.app.role.RoleManager.ROLE_CALL_SCREENING)) {
+                Log.d(TAG, "Skipping Receiver: ROLE_CALL_SCREENING is held, Service will handle.")
+                return
+            }
+        }
+
         val phoneState = intent.getStringExtra(TelephonyManager.EXTRA_STATE) ?: return
         Log.d(TAG, "Phone state: $phoneState (last: $lastState)")
 

--- a/ringersong/src/main/java/com/RingerSong/free/service/RingerPlaybackService.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/service/RingerPlaybackService.kt
@@ -34,6 +34,7 @@ class RingerPlaybackService : Service() {
     @Inject lateinit var spotifyPlayer: SpotifyPlayerManager
     @Inject lateinit var appleMusicPlayer: AppleMusicPlayerManager
     @Inject lateinit var youtubeMusicPlayer: YouTubeMusicPlayerManager
+    @Inject lateinit var tidalPlayerManager: TidalPlayerManager
 
     private val scope = CoroutineScope(Dispatchers.Main + Job())
     private var mediaPlayer: MediaPlayer? = null
@@ -279,11 +280,31 @@ class RingerPlaybackService : Service() {
                 SongSource.LOCAL -> playLocalSong(song, segmentPlay.startMs, segmentPlay.durationMs)
                 SongSource.YOUTUBE_MUSIC -> playYouTubeSong(song, segmentPlay.startMs, segmentPlay.durationMs)
                 SongSource.APPLE_MUSIC -> playAppleMusicSong(song, segmentPlay.startMs, segmentPlay.durationMs)
+                SongSource.TIDAL -> playTidalSong(song, segmentPlay.startMs, segmentPlay.durationMs)
                 else -> {
                     Log.w(TAG, "Unsupported song source: ${song.source}")
                     stopSelf()
                 }
             }
+        }
+    }
+
+    private suspend fun playTidalSong(song: SongEntry, startMs: Long, durationMs: Long) {
+        Log.d(TAG, "Attempting to play Tidal song: ${song.title}")
+        val success = tidalPlayerManager.playTrack(song)
+        if (success) {
+            isPlaying = true
+            playbackJob = scope.launch {
+                delay(durationMs)
+                Log.d(TAG, "Tidal segment duration passed")
+                stopPlayback()
+                restoreSystemRinger()
+                stopForeground(true)
+                stopSelf()
+            }
+        } else {
+            Log.e(TAG, "Failed to launch Tidal")
+            stopSelf()
         }
     }
 

--- a/ringersong/src/main/java/com/RingerSong/free/service/TidalPlayerManager.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/service/TidalPlayerManager.kt
@@ -1,0 +1,70 @@
+package com.RingerSong.free.service
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import com.RingerSong.free.data.SongEntry
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TidalPlayerManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private const val TAG = "TidalPlayerManager"
+        // Tidal package name
+        private const val TIDAL_PACKAGE = "com.aspiro.tidal"
+    }
+
+    /**
+     * Attempts to play a Tidal track by launching the app with a deep link.
+     */
+    suspend fun playTrack(song: SongEntry): Boolean = withContext(Dispatchers.Main) {
+        try {
+            val uriString = song.uri
+            val uri = if (uriString.startsWith("http")) {
+                Uri.parse(uriString)
+            } else if (uriString.startsWith("tidal://")) {
+                Uri.parse(uriString)
+            } else if (uriString.all { it.isDigit() }) {
+                // If ID, try tidal://track/ID
+                Uri.parse("tidal://track/$uriString")
+            } else {
+                 Uri.parse(uriString)
+            }
+
+            Log.d(TAG, "Attempting to launch Tidal with URI: $uri")
+
+            // Check for overlay permission
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M &&
+                !android.provider.Settings.canDrawOverlays(context)) {
+                Log.w(TAG, "Cannot launch Tidal: Missing Overlay Permission")
+                 // Continue anyway, might work if activity is top
+            }
+
+            val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+                setPackage(TIDAL_PACKAGE)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+
+            val packageManager = context.packageManager
+            if (intent.resolveActivity(packageManager) != null) {
+                context.startActivity(intent)
+                Log.d(TAG, "Tidal intent launched")
+                return@withContext true
+            } else {
+                Log.e(TAG, "Tidal app not installed")
+                return@withContext false
+            }
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error launching Tidal", e)
+            return@withContext false
+        }
+    }
+}

--- a/ringersong/src/main/java/com/RingerSong/free/ui/HomeScreen.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/ui/HomeScreen.kt
@@ -129,6 +129,7 @@ fun HomeScreen(
     onClearYouTubeSearch: () -> Unit,
     onAddYouTubeTrack: (SpotifyTrack) -> Unit,
     onConnectSpotify: ( (Boolean) -> Unit ) -> Unit,
+    onAddFromLink: (String) -> Unit,
     userCapabilities: String,
     snackbarHostState: SnackbarHostState
 ) {
@@ -287,7 +288,10 @@ fun HomeScreen(
                 visible = showContent.value,
                 enter = fadeIn() + slideInVertically(initialOffsetY = { it / 3 })
             ) {
-                AppleMusicPlaceholderSection(modifier = Modifier.fillMaxWidth())
+                UniversalLinkAddSection(
+                    onAdd = onAddFromLink,
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -1181,31 +1185,45 @@ private fun SpotifyResultRow(
 }
 
 @Composable
-private fun AppleMusicPlaceholderSection(modifier: Modifier = Modifier) {
+private fun UniversalLinkAddSection(
+    onAdd: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var link by remember { mutableStateOf("") }
+
     SectionCard(modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
-                    text = "Add from Apple Music",
+                    text = "Add from Link",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold
                 )
                 Text(
-                    text = "Apple Music integration is coming soon.",
+                    text = "Paste a link from Spotify, YouTube Music, Apple Music, or Tidal.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
+
+            OutlinedTextField(
+                value = link,
+                onValueChange = { link = it },
+                label = { Text("Paste song link") },
+                placeholder = { Text("https://...") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
             Button(
-                onClick = { /* No-op or show info dialog */ },
-                enabled = false,
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(
-                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                onClick = {
+                    onAdd(link)
+                    link = ""
+                },
+                enabled = link.isNotBlank(),
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Coming Soon")
+                Text("Add Track")
             }
         }
     }

--- a/ringersong/src/main/java/com/RingerSong/free/ui/RingerSongApp.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/ui/RingerSongApp.kt
@@ -146,6 +146,14 @@ private fun AppNavHost(
                          onResult(success)
                      }
                 },
+                onAddFromLink = { link ->
+                    viewModel.addFromLink(link) { message ->
+                        coroutineScope.launch { snackbarHostState.showSnackbar(message) }
+                        if (!message.startsWith("Error") && !message.startsWith("Invalid")) {
+                             activity?.let { AdServices.showInterstitial(it) }
+                        }
+                    }
+                },
                 snackbarHostState = snackbarHostState
             )
         }

--- a/ringersong/src/main/java/com/RingerSong/free/viewmodel/RingerViewModel.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/viewmodel/RingerViewModel.kt
@@ -740,4 +740,87 @@ class RingerViewModel @Inject constructor(
             onComplete(info)
         }
     }
+
+    fun addFromLink(url: String, onResult: (String) -> Unit) {
+        val trimmed = url.trim()
+        if (trimmed.isEmpty()) {
+            onResult("Invalid link")
+            return
+        }
+
+        viewModelScope.launch {
+            val songId = UUID.randomUUID().toString()
+            var title = "Linked Track"
+            var uri = trimmed
+            var source = SongSource.LOCAL
+            var durationMs: Long? = null
+
+            // Detect Source
+            if (trimmed.contains("spotify.com") || trimmed.startsWith("spotify:")) {
+                 source = SongSource.SPOTIFY
+                 title = "Spotify Track"
+            } else if (trimmed.contains("music.youtube.com") || trimmed.contains("youtube.com") || trimmed.startsWith("youtube:")) {
+                 source = SongSource.YOUTUBE_MUSIC
+                 title = "YouTube Music Track"
+                 val videoId = if (trimmed.startsWith("youtube:video:")) {
+                     trimmed.removePrefix("youtube:video:")
+                 } else {
+                     Uri.parse(trimmed).getQueryParameter("v") ?: trimmed.substringAfterLast("/")
+                 }
+                 uri = "youtube:video:$videoId"
+            } else if (trimmed.contains("music.apple.com")) {
+                 source = SongSource.APPLE_MUSIC
+                 title = "Apple Music Track"
+            } else if (trimmed.contains("tidal.com") || trimmed.startsWith("tidal:")) {
+                 source = SongSource.TIDAL
+                 title = "Tidal Track"
+            } else {
+                 onResult("Unsupported link type. Please use Spotify, YouTube Music, Apple Music, or Tidal.")
+                 return@launch
+            }
+
+            // Add to local state
+            val songEntry = SongEntry(
+                id = songId,
+                title = title,
+                uri = uri,
+                source = source,
+                durationMs = durationMs,
+                addedAt = System.currentTimeMillis()
+            )
+
+            withContext(Dispatchers.IO) {
+                store.update { current ->
+                    val updatedSongs = current.songs + songEntry
+                    val updatedOrder = current.songOrder + songEntry.id
+                    current.copy(songs = updatedSongs, songOrder = updatedOrder)
+                }
+            }
+
+            // Sync to Firestore
+            val uid = auth?.currentUser?.uid
+            if (uid != null && db != null) {
+                val trackData = mapOf(
+                    "uri" to uri,
+                    "source" to source.name,
+                    "title" to title,
+                    "artist" to "Unknown Artist",
+                    "durationMs" to (durationMs ?: 0L),
+                    "addedAt" to com.google.firebase.Timestamp.now(),
+                    "downloaded" to false
+                )
+
+                db!!.collection("users").document(uid).collection("ringer_playlist")
+                    .add(trackData)
+                    .addOnSuccessListener {
+                        onResult("Added $title")
+                    }
+                    .addOnFailureListener {
+                         onResult("Added locally (Sync failed)")
+                    }
+            } else {
+                onResult("Added locally")
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR addresses stability issues in the `ringersong` module by preventing double-handling of incoming calls when the Call Screening role is held. It also expands the app's capability to use external streaming services as ringer sources by implementing support for Tidal deep links and adding a universal "Add from Link" feature that parses Spotify, YouTube Music, Apple Music, and Tidal URLs.

---
*PR created automatically by Jules for task [14785386899948834789](https://jules.google.com/task/14785386899948834789) started by @DamienLove*