### PR TITLE
Fix widget manifest conflict in Pro and bug report template URL

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
@@ -1521,6 +1521,7 @@ class MainViewModel @Inject constructor(
         // Direct to GitHub issue form so users land on the correct bug report page.
         return Uri.parse(BUG_REPORT_PAGE_URL)
             .buildUpon()
+            .appendQueryParameter("template", "bug_report.md")
             .appendQueryParameter("title", subjectSuffix)
             .appendQueryParameter("body", formattedBody)
             .build()

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -6,28 +6,6 @@
         <provider
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
-
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Fixed Issue #76 by removing redundant widget declarations from androidApp/src/pro/AndroidManifest.xml to resolve manifest merge conflicts.
Fixed Issue #77 by updating MainViewModel.kt to append '?template=bug_report.md' to the bug report URL, ensuring the correct GitHub issue template is used.

---
*PR created automatically by Jules for task [5979348898501433930](https://jules.google.com/task/5979348898501433930) started by @DamienLove*