### PR TITLE
Implement Immediate SMS Sync via FCM Wake-up

### DIFF
--- a/androidApp/src/main/java/com/pulselink/data/messaging/FirebaseMessagingService.kt
+++ b/androidApp/src/main/java/com/pulselink/data/messaging/FirebaseMessagingService.kt
@@ -21,6 +21,7 @@ class PulseLinkFirebaseMessagingService : FirebaseMessagingService() {
 
     @Inject lateinit var linkChannelService: LinkChannelService
     @Inject lateinit var smsRelayService: SmsRelayService
+    @Inject lateinit var smsSyncTrigger: com.pulselink.data.sms.SmsSyncTrigger
     @Inject lateinit var settingsRepository: SettingsRepository
     @Inject lateinit var firestore: FirebaseFirestore
     @Inject lateinit var auth: FirebaseAuth
@@ -44,6 +45,11 @@ class PulseLinkFirebaseMessagingService : FirebaseMessagingService() {
             // If the app was dead, PulseLinkApp.onCreate() calls this too, but
             // explicit call here guarantees it for all entry points.
             smsRelayService.start()
+
+            if (message.data["reason"] == "SYNC_REQUEST") {
+                Log.d(TAG, "Triggering immediate sync due to SYNC_REQUEST")
+                smsSyncTrigger.triggerSync()
+            }
             return
         }
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,3 +34,4 @@ export {
 } from "./billing";
 export {getSpotifyAccessToken} from "./spotify";
 export {submitExtension, onExtensionSubmitted} from "./extensions";
+export {onUserUpdated} from "./sync";

--- a/functions/src/sync.ts
+++ b/functions/src/sync.ts
@@ -1,0 +1,63 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+export const onUserUpdated = functions.firestore
+    .document("users/{userId}")
+    .onUpdate(async (change, context) => {
+      const before = change.before.data();
+      const after = change.after.data();
+
+      // Check if syncRequestedAt changed
+      const beforeSync = before?.syncRequestedAt;
+      const afterSync = after?.syncRequestedAt;
+
+      // Check if remoteWebAccessEnabled changed to true
+      const beforeAccess = before?.remoteWebAccessEnabled;
+      const afterAccess = after?.remoteWebAccessEnabled;
+      const accessEnabled = !beforeAccess && afterAccess;
+
+      const syncRequested = afterSync && (!beforeSync || !beforeSync.isEqual(afterSync));
+
+      if (!syncRequested && !accessEnabled) return;
+
+      const userId = context.params.userId;
+      console.log(`Sync requested for user ${userId} (manual: ${syncRequested}, auto-enable: ${accessEnabled})`);
+
+      const db = admin.firestore();
+      // Find devices
+      const devicesQuery = await db.collection("devices")
+          .where("uid", "==", userId)
+          .get();
+
+      if (devicesQuery.empty) return;
+
+      const tokens: string[] = [];
+      devicesQuery.forEach((doc) => {
+        const data = doc.data();
+        if (data.fcmToken) {
+          tokens.push(data.fcmToken);
+        }
+      });
+
+      if (tokens.length === 0) return;
+
+      const payload = {
+        data: {
+          type: "SMS_RELAY",
+          userId: userId,
+          reason: "SYNC_REQUEST",
+          timestamp: String(Date.now()),
+        },
+        tokens: tokens,
+        android: {
+          priority: "high" as const,
+        },
+      };
+
+      try {
+        await admin.messaging().sendMulticast(payload);
+        console.log(`Sent sync trigger to ${tokens.length} devices`);
+      } catch (error) {
+        console.error("Error sending sync trigger", error);
+      }
+    });


### PR DESCRIPTION
This change ensures that the web application stays synchronized with the user's SMS messages in real-time, even if the Android application is in the background or killed. 

It addresses the requirement for "immediate direct" synchronization by:
1.  **Closing the gap for dead-app synchronization:** When a user requests a sync from the web dashboard (updating `syncRequestedAt` in Firestore), a new Cloud Function (`onUserUpdated`) detects this change and sends a high-priority FCM message to the user's device.
2.  **Handling the wake-up:** The Android app's `FirebaseMessagingService` now listens for this specific FCM message (`reason: "SYNC_REQUEST"`) and invokes `SmsSyncTrigger` to perform an immediate sync.
3.  **Verifying existing event-driven triggers:** Confirmed that `SmsSyncManager` (via ContentObserver) and `PulseLinkSmsReceiver` already handle synchronization for incoming/outgoing messages and Premium upgrades while the app is running.
4.  **Adhering to "No Interval Syncs":** No periodic polling was added; the solution relies entirely on event-based triggers (FCM, Broadcasts, ContentObservers).

---
*PR created automatically by Jules for task [2681679343869542699](https://jules.google.com/task/2681679343869542699) started by @DamienLove*