### PR TITLE
🎨 Palette: Login Form UX Improvements

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -3921,6 +3921,7 @@ function App() {
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="you@example.com"
                   autoComplete="email"
+                  autoFocus
                 />
               </label>
               <div className="login-field">
@@ -3940,6 +3941,7 @@ function App() {
                     className="password-toggle-btn"
                     onClick={() => setShowPassword(!showPassword)}
                     aria-label={showPassword ? "Hide password" : "Show password"}
+                    title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (
                       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -1,0 +1,27 @@
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Login UX Improvements', () => {
+  test('Email input should be autofocused on load', async ({ page }) => {
+    // Navigate to root (Login page)
+    await page.goto('/');
+
+    const emailInput = page.getByPlaceholder('you@example.com');
+    await expect(emailInput).toBeVisible();
+    await expect(emailInput).toBeFocused();
+  });
+
+  test('Password toggle button should have tooltip title', async ({ page }) => {
+    await page.goto('/');
+
+    const toggleBtn = page.locator('.password-toggle-btn');
+    await expect(toggleBtn).toBeVisible();
+
+    // Initially hidden (password type)
+    await expect(toggleBtn).toHaveAttribute('title', 'Show password');
+
+    // Click to show
+    await toggleBtn.click();
+    await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+  });
+});


### PR DESCRIPTION
🎨 Palette: Login Form UX Improvements

💡 What:
- Added `autoFocus` to the Email input on the login page.
- Added a dynamic `title` tooltip ("Show password" / "Hide password") to the password toggle button.

🎯 Why:
- Users expect to start typing their email immediately upon landing on a dedicated login page. This saves a click.
- The password toggle icon was accessible via `aria-label` but lacked a visual tooltip for mouse users, which is a standard pattern for icon-only buttons in this app.

📸 Verification:
- Created a new Playwright test `web/tests/login_ux.spec.js` that confirms the email input is focused on load and the toggle button has the correct title attribute.
- Visual verification confirmed the focus ring appears on the input.

♿ Accessibility:
- Explicit `title` attribute reinforces the purpose of the icon button for sighted users who rely on tooltips.
- `autoFocus` improves keyboard navigation efficiency for the primary action.

---
*PR created automatically by Jules for task [16817770018859778061](https://jules.google.com/task/16817770018859778061) started by @DamienLove*