### PR TITLE
🛡️ Sentinel: Enforce Content Security Policy

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -33,7 +33,7 @@
             "value": "strict-origin-when-cross-origin"
           },
           {
-            "key": "Content-Security-Policy-Report-Only",
+            "key": "Content-Security-Policy",
             "value": "default-src 'self'; script-src 'self' https://maps.googleapis.com https://apis.google.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src *; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self';"
           }
         ]


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Enforce Content Security Policy

🚨 Severity: HIGH
💡 Vulnerability: The Content Security Policy was configured in `Report-Only` mode, which logs violations but does not block malicious content. This left the application vulnerable to XSS and other attacks despite having a policy definition.
🎯 Impact: Attackers could potentially execute malicious scripts or load unauthorized resources if an injection vulnerability were found, as the browser would not block them.
🔧 Fix: Renamed the header key from `Content-Security-Policy-Report-Only` to `Content-Security-Policy` in `firebase.json` to enable active enforcement.
✅ Verification: Verified `firebase.json` content and ensured the web project builds successfully with the new configuration.

---
*PR created automatically by Jules for task [9448254392826881851](https://jules.google.com/task/9448254392826881851) started by @DamienLove*