### PR TITLE
🎨 Palette: Restore focus on Command Palette close

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-28 - Image Load Error Fallbacks
 **Learning:** User-provided URLs for avatars often break (404s), resulting in ugly browser-default broken image icons that degrade perceived app quality. Relying solely on "if URL exists" logic is insufficient.
 **Action:** Implemented a `useState` + `onError` handler pattern in the `Avatar` component to detect load failures and automatically revert to the deterministic initial fallback, maintaining UI elegance even with bad data.
+
+## 2024-05-29 - Focus Management in Modals
+**Learning:** When a modal (like Command Palette) closes, if focus is not returned to the triggering element, keyboard users are lost at the `<body>` level, forcing them to re-navigate the entire page.
+**Action:** Implemented a focus restoration pattern using `useRef` to capture `document.activeElement` on open and restore it on close.

--- a/web/src/CommandPalette.jsx
+++ b/web/src/CommandPalette.jsx
@@ -19,13 +19,20 @@ export default function CommandPalette({ isOpen, onClose, setActivePanel, action
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef(null);
   const listRef = useRef(null);
+  const previousFocusRef = useRef(null);
 
   useEffect(() => {
     if (isOpen) {
+      previousFocusRef.current = document.activeElement;
       setQuery('');
       setSelectedIndex(0);
       // Small timeout to allow render before focus
       setTimeout(() => inputRef.current?.focus(), 50);
+    } else {
+      if (previousFocusRef.current) {
+        previousFocusRef.current.focus();
+        previousFocusRef.current = null;
+      }
     }
   }, [isOpen]);
 

--- a/web/tests/command_palette_focus.spec.js
+++ b/web/tests/command_palette_focus.spec.js
@@ -1,0 +1,40 @@
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Command Palette UX', () => {
+  test.beforeEach(async ({ page }) => {
+    // Enable mock user mode
+    await page.goto('/?mock_user=true');
+    await page.waitForTimeout(1000); // Allow app to hydrate
+  });
+
+  test('should restore focus to the trigger element on close', async ({ page }) => {
+    // Navigate to Beacon panel to see the Command Palette button
+    await page.getByLabel('Beacon').click();
+
+    // 1. Locate the Command Palette button in the Sidebar
+    const paletteBtn = page.getByLabel('Open command palette (Ctrl+K)');
+    await expect(paletteBtn).toBeVisible();
+
+    // 2. Focus the button explicitly to simulate keyboard navigation or click
+    await paletteBtn.focus();
+    await expect(paletteBtn).toBeFocused();
+
+    // 3. Open the palette
+    await paletteBtn.click();
+
+    // 4. Verify focus moves to the Command Palette input
+    const paletteInput = page.getByRole('combobox', { name: 'Command input' });
+    await expect(paletteInput).toBeVisible();
+    await expect(paletteInput).toBeFocused();
+
+    // 5. Close the palette via Escape key
+    await page.keyboard.press('Escape');
+
+    // 6. Verify focus is restored to the trigger button
+    await expect(paletteInput).not.toBeVisible();
+
+    // This expectation is expected to fail initially because focus restoration isn't implemented
+    await expect(paletteBtn).toBeFocused();
+  });
+});


### PR DESCRIPTION
💡 What: Implemented focus restoration for the Command Palette using `useRef` to capture the previously focused element.
🎯 Why: Keyboard users were losing focus context when closing the modal, forcing them to re-navigate from the document body.
♿ Accessibility: Ensures WCAG compliance for modal focus management.

- Modified `web/src/CommandPalette.jsx` to capture and restore focus.
- Added reproduction test `web/tests/command_palette_focus.spec.js`.
- Verified with existing UX tests.

---
*PR created automatically by Jules for task [16807062182345444457](https://jules.google.com/task/16807062182345444457) started by @DamienLove*