### PR TITLE
Refactor calling logic

### DIFF
--- a/androidApp/src/main/java/com/pulselink/domain/model/Contact.kt
+++ b/androidApp/src/main/java/com/pulselink/domain/model/Contact.kt
@@ -45,3 +45,6 @@ enum class EscalationTier { EMERGENCY, CHECK_IN }
 
 @Serializable
 enum class RemotePresence { ONLINE, RECENT, OFFLINE, STALE, UNKNOWN }
+
+fun Contact.primaryPhone(): String? =
+    (listOf(phoneNumber) + additionalPhones).firstOrNull { it.isNotBlank() }

--- a/androidApp/src/main/java/com/pulselink/ui/BeaconInboxActivity.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/BeaconInboxActivity.kt
@@ -94,6 +94,7 @@ import com.pulselink.ui.state.MainViewModel
 import com.pulselink.ui.state.SmsInboxViewModel
 import com.pulselink.ui.state.SmsLinesViewModel
 import com.pulselink.ui.state.SmsThreadViewModel
+import com.pulselink.domain.model.primaryPhone
 import com.pulselink.domain.model.LineInboxMode
 import com.pulselink.domain.model.LineSendPreference
 import com.pulselink.ui.theme.PulseLinkTheme
@@ -835,9 +836,7 @@ class BeaconInboxActivity : ComponentActivity() {
                                     val summaryState by threadViewModel.summaryState.collectAsStateWithLifecycle()
                                     val composeState by threadViewModel.composeState.collectAsStateWithLifecycle()
                                     val decodedAddress = Uri.decode(address)
-                                    val callNumber = contact?.phoneNumber
-                                        ?.takeIf { it.isNotBlank() }
-                                        ?: contact?.additionalPhones?.firstOrNull { it.isNotBlank() }
+                                    val callNumber = contact?.primaryPhone()
                                         ?: decodedAddress.takeIf { it.isNotBlank() }
                                     val onCallThread = callNumber?.let { number ->
                                         {

--- a/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
@@ -76,6 +76,7 @@ import com.pulselink.data.ads.AppOpenAdController
 import com.pulselink.data.sms.MessageNotificationManager
 import com.pulselink.data.contacts.DeviceContact
 import com.pulselink.domain.model.Contact
+import com.pulselink.domain.model.primaryPhone
 import com.pulselink.domain.model.ManualMessageResult
 import com.pulselink.domain.model.LineInboxMode
 import com.pulselink.domain.model.LineSendPreference
@@ -2558,9 +2559,6 @@ private fun rememberCancelEmergencyLauncher(
 
 private const val CANCEL_EMERGENCY_AUTHENTICATORS =
     BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
-
-private fun Contact.primaryPhone(): String? =
-    (listOf(phoneNumber) + additionalPhones).firstOrNull { it.isNotBlank() }
 
 private fun placeCall(
     activity: MainActivity,


### PR DESCRIPTION
Refactored calling logic to ensure consistency across `MainActivity` and `BeaconInboxActivity`.
Moved `primaryPhone()` logic to a shared extension in `Contact.kt`.
This solidifies the "calling feature" implementation requested in issue #546.

---
*PR created automatically by Jules for task [1820046173749732505](https://jules.google.com/task/1820046173749732505) started by @DamienLove*