### PR TITLE
fix: use encoded mailto URI for trusted contact email

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/screens/ContactDetailScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/ContactDetailScreen.kt
@@ -279,7 +279,7 @@ private fun LinkStatusSection(
                                     // Use ACTION_SENDTO with encoded mailto URI to ensure subject/body are populated in all clients
                                     // Also put extras directly for clients that ignore URI params (e.g. Gmail)
                                     val emailIntent = Intent(Intent.ACTION_SENDTO).apply {
-                                        data = Uri.parse("mailto:${contact.email ?: ""}")
+                                        data = Uri.parse(EmailUtils.createMailtoUriString(contact.email, rawSubject, rawBody))
                                         putExtra(Intent.EXTRA_SUBJECT, rawSubject)
                                         putExtra(Intent.EXTRA_TEXT, rawBody)
                                     }


### PR DESCRIPTION
Fixes Issue #66 where the email composer opened without the subject and body pre-filled.
The `ContactDetailScreen` was manually constructing a `mailto:` URI without parameters and relying on `Intent.EXTRA_*` which is not supported by all clients in `ACTION_SENDTO` mode with a `mailto` scheme.
The fix uses the existing `EmailUtils.createMailtoUriString` helper to encode the subject and body directly into the URI, ensuring broader compatibility.

---
*PR created automatically by Jules for task [16986386817634672546](https://jules.google.com/task/16986386817634672546) started by @DamienLove*