### PR TITLE
🛡️ Sentinel: Enforce CSP and add Permissions-Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** The frontend attempted to write "safe" content directly to a public, read-only collection (`themes_public`) to bypass moderation, which failed due to correct Firestore rules but highlighted a flaw in the design where client-side logic determined security posture.
 **Learning:** Never rely on client-side logic ("it has no images") to bypass security queues. If the destination is protected, all writes must go through a privileged backend (Cloud Function) or a submission queue (`themes_submissions`).
 **Prevention:** Implement the "Submission Queue" pattern: Clients always write to a pending collection. A Cloud Function trigger validates the content server-side and promotes it to the public collection if safe, or flags it for review.
+
+## 2024-06-01 - [Inactive CSP Configuration]
+**Vulnerability:** The Content Security Policy was configured as `Content-Security-Policy-Report-Only`, which provides no active protection against XSS or injection attacks, effectively leaving the application unprotected.
+**Learning:** `Report-Only` headers are often left over from debugging/implementation phases and must be explicitly switched to enforcing mode (`Content-Security-Policy`) for production security.
+**Prevention:** Audit `firebase.json` headers to ensure `Content-Security-Policy` is used without the `-Report-Only` suffix unless actively debugging.

--- a/firebase.json
+++ b/firebase.json
@@ -33,8 +33,12 @@
             "value": "strict-origin-when-cross-origin"
           },
           {
-            "key": "Content-Security-Policy-Report-Only",
+            "key": "Content-Security-Policy",
             "value": "default-src 'self'; script-src 'self' https://maps.googleapis.com https://apis.google.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src *; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self';"
+          },
+          {
+            "key": "Permissions-Policy",
+            "value": "camera=(), microphone=(), geolocation=(self)"
           }
         ]
       }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Enforce Content Security Policy

🚨 Severity: HIGH
💡 Vulnerability: The web application was using `Content-Security-Policy-Report-Only`, which does not block malicious content, leaving the application vulnerable to XSS and injection attacks.
🎯 Impact: Attackers could potentially execute arbitrary scripts or load malicious resources if an injection vulnerability were found.
🔧 Fix: Renamed the header to `Content-Security-Policy` to enforce the rules. Added `Permissions-Policy` to restrict hardware access.
✅ Verification: Verified `firebase.json` syntax and header configuration.

---
*PR created automatically by Jules for task [3417981096894289958](https://jules.google.com/task/3417981096894289958) started by @DamienLove*