### PR TITLE
🎨 Palette: Restore focus on Command Palette close

### DIFF
--- a/web/src/CommandPalette.jsx
+++ b/web/src/CommandPalette.jsx
@@ -19,14 +19,20 @@ export default function CommandPalette({ isOpen, onClose, setActivePanel, action
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef(null);
   const listRef = useRef(null);
+  const restoreFocusRef = useRef(null);
 
   useEffect(() => {
+    let timeoutId;
     if (isOpen) {
+      restoreFocusRef.current = document.activeElement;
       setQuery('');
       setSelectedIndex(0);
       // Small timeout to allow render before focus
-      setTimeout(() => inputRef.current?.focus(), 50);
+      timeoutId = setTimeout(() => inputRef.current?.focus(), 50);
+    } else {
+      restoreFocusRef.current?.focus({ preventScroll: true });
     }
+    return () => clearTimeout(timeoutId);
   }, [isOpen]);
 
   const filteredItems = useMemo(() => {

--- a/web/tests/command_palette_focus.spec.js
+++ b/web/tests/command_palette_focus.spec.js
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Command Palette Focus', () => {
+  test.beforeEach(async ({ page }) => {
+    // Enable mock user mode
+    await page.goto('/?mock_user=true');
+    // Wait for the app to load
+    await page.waitForSelector('.sidebar');
+
+    // Navigate to Beacon panel to ensure the Command Palette button is visible in Sidebar
+    // The nav item has title="Beacon"
+    await page.locator('.nav-item[title="Beacon"]').click();
+  });
+
+  test('should restore focus to trigger button after closing with Escape', async ({ page }) => {
+    // Locate the trigger button in the sidebar
+    // Note: The button has aria-label="Open command palette (Ctrl+K)"
+    const triggerButton = page.locator('button[aria-label="Open command palette (Ctrl+K)"]');
+
+    // Ensure it's visible and click it
+    await expect(triggerButton).toBeVisible();
+    await triggerButton.click();
+
+    // Verify Command Palette is open and input is focused
+    const paletteInput = page.locator('.command-palette-input');
+    await expect(paletteInput).toBeVisible();
+    await expect(paletteInput).toBeFocused();
+
+    // Press Escape to close
+    await page.keyboard.press('Escape');
+
+    // Verify Command Palette is closed
+    await expect(paletteInput).not.toBeVisible();
+
+    // Verify focus is restored to the trigger button
+    await expect(triggerButton).toBeFocused();
+  });
+});


### PR DESCRIPTION
💡 What: Implemented focus restoration in the Command Palette component.
🎯 Why: To improve accessibility for keyboard users. When the palette is closed, focus should return to the element that triggered it.
📸 Before/After: Focus was lost to body; now it returns to the trigger button.
♿ Accessibility: Ensures WCAG compliance for modal dialog focus management.
Related: Added web/tests/command_palette_focus.spec.js

---
*PR created automatically by Jules for task [417320567352332196](https://jules.google.com/task/417320567352332196) started by @DamienLove*