### PR TITLE
Implement Web Message Access Sync Infrastructure

### DIFF
--- a/androidApp/src/main/java/com/pulselink/data/messaging/FirebaseMessagingService.kt
+++ b/androidApp/src/main/java/com/pulselink/data/messaging/FirebaseMessagingService.kt
@@ -8,6 +8,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.pulselink.data.link.LinkChannelService
 import com.pulselink.data.sms.SmsRelayService
+import com.pulselink.data.sms.SmsSyncTrigger
 import com.pulselink.domain.repository.SettingsRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -21,6 +22,7 @@ class PulseLinkFirebaseMessagingService : FirebaseMessagingService() {
 
     @Inject lateinit var linkChannelService: LinkChannelService
     @Inject lateinit var smsRelayService: SmsRelayService
+    @Inject lateinit var smsSyncTrigger: SmsSyncTrigger
     @Inject lateinit var settingsRepository: SettingsRepository
     @Inject lateinit var firestore: FirebaseFirestore
     @Inject lateinit var auth: FirebaseAuth
@@ -38,6 +40,12 @@ class PulseLinkFirebaseMessagingService : FirebaseMessagingService() {
         Log.d(TAG, "Message received from: ${message.from}")
 
         val type = message.data["type"]
+        if (type == "SYNC_REQUEST") {
+            Log.d(TAG, "Received SYNC_REQUEST trigger")
+            smsSyncTrigger.triggerSync()
+            return
+        }
+
         if (type == "SMS_RELAY") {
             Log.d(TAG, "Received SMS_RELAY trigger")
             // Ensure the relay service is listening. This is idempotent.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,3 +34,4 @@ export {
 } from "./billing";
 export {getSpotifyAccessToken} from "./spotify";
 export {submitExtension, onExtensionSubmitted} from "./extensions";
+export {onUserUpdated} from "./sync";

--- a/functions/src/sync.ts
+++ b/functions/src/sync.ts
@@ -1,0 +1,75 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+export const onUserUpdated = functions.firestore
+    .document("users/{userId}")
+    .onUpdate(async (change, context) => {
+      const newData = change.after.data();
+      const oldData = change.before.data();
+
+      // Check if syncRequestedAt changed
+      const newSyncRequest = newData.syncRequestedAt;
+      const oldSyncRequest = oldData.syncRequestedAt;
+
+      // Also check if remoteWebAccessEnabled turned ON
+      const newWebAccess = newData.remoteWebAccessEnabled;
+      const oldWebAccess = oldData.remoteWebAccessEnabled;
+
+      // Compare Timestamps
+      let syncRequested = false;
+      if (newSyncRequest && !oldSyncRequest) {
+        syncRequested = true;
+      } else if (newSyncRequest && oldSyncRequest) {
+        // Use isEqual if available, otherwise compare seconds/nanoseconds
+        if (typeof newSyncRequest.isEqual === "function") {
+          syncRequested = !newSyncRequest.isEqual(oldSyncRequest);
+        } else {
+          syncRequested = newSyncRequest.seconds !== oldSyncRequest.seconds ||
+                          newSyncRequest.nanoseconds !== oldSyncRequest.nanoseconds;
+        }
+      }
+
+      const webAccessEnabled = (newWebAccess === true && oldWebAccess !== true);
+
+      if (syncRequested || webAccessEnabled) {
+        const userId = context.params.userId;
+        console.log(`Sync requested for user ${userId}`);
+
+        const db = admin.firestore();
+        // Find user's devices with FCM tokens
+        const devicesQuery = await db.collection("devices")
+            .where("uid", "==", userId)
+            .get();
+
+        if (devicesQuery.empty) return;
+
+        const tokens: string[] = [];
+        devicesQuery.forEach((doc) => {
+          const d = doc.data();
+          if (d.fcmToken) {
+            tokens.push(d.fcmToken);
+          }
+        });
+
+        if (tokens.length > 0) {
+          const payload = {
+            data: {
+              type: "SYNC_REQUEST",
+              reason: "web_request",
+              timestamp: String(Date.now()),
+            },
+            tokens: tokens,
+            android: {
+              priority: "high" as const,
+            },
+          };
+
+          try {
+            const response = await admin.messaging().sendMulticast(payload);
+            console.log(`Sent SYNC_REQUEST to ${response.successCount} devices.`);
+          } catch (e) {
+            console.error("Failed to send SYNC_REQUEST", e);
+          }
+        }
+      }
+    });


### PR DESCRIPTION
Implemented the backend and Android infrastructure to support "Request Phone Sync" from the Web App.
When a user clicks "Request Phone Sync" on the web, `syncRequestedAt` is updated in Firestore.
A new Cloud Function `onUserUpdated` listens for this change and sends a high-priority FCM message (`type: "SYNC_REQUEST"`) to the user's devices.
The Android app's `FirebaseMessagingService` now intercepts this message and triggers `SmsSyncTrigger`, initiating an immediate SMS sync to Firestore.
Verified via build checks for `functions`, `web`, and `androidApp`.


---
*PR created automatically by Jules for task [3122261682525261194](https://jules.google.com/task/3122261682525261194) started by @DamienLove*