### PR TITLE
fix: remove duplicate widget declarations from Pro/Premium manifests

### DIFF
--- a/androidApp/src/premium/AndroidManifest.xml
+++ b/androidApp/src/premium/AndroidManifest.xml
@@ -8,27 +8,6 @@
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
 
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -7,27 +7,6 @@
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
 
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Removed duplicate declarations of `PulseLinkWidgetProvider`, `PulseLinkWidgetActionReceiver`, and `PulseLinkWidgetService` from `androidApp/src/pro/AndroidManifest.xml` and `androidApp/src/premium/AndroidManifest.xml`.
This ensures that the single source of truth in `androidApp/src/main/AndroidManifest.xml` is used, resolving potential conflicts and alignment with project structure guidelines.

---
*PR created automatically by Jules for task [14183070348912881116](https://jules.google.com/task/14183070348912881116) started by @DamienLove*