### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSS Injection in Theme Auto-Approval

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** The frontend attempted to write "safe" content directly to a public, read-only collection (`themes_public`) to bypass moderation, which failed due to correct Firestore rules but highlighted a flaw in the design where client-side logic determined security posture.
 **Learning:** Never rely on client-side logic ("it has no images") to bypass security queues. If the destination is protected, all writes must go through a privileged backend (Cloud Function) or a submission queue (`themes_submissions`).
 **Prevention:** Implement the "Submission Queue" pattern: Clients always write to a pending collection. A Cloud Function trigger validates the content server-side and promotes it to the public collection if safe, or flags it for review.
+
+## 2024-05-27 - CSS Injection via Auto-Approval Bypass
+**Vulnerability:** The theme auto-approval logic (`onThemeSubmitted`) checked for explicit image fields (`backgroundImageUrl`) but failed to validate color fields (e.g., `primaryColor`). Attackers could inject CSS `url()` values into color fields to load external images, bypassing the "no images" check and enabling tracking/privacy leaks.
+**Learning:** "Safe" content (like colors) can still be vectors for external resource loading if not validated against strict patterns (e.g., regex for hex/rgb). Validating *structure* is as important as validating *content*.
+**Prevention:** Scan ALL fields for potentially dangerous patterns (like `url(`) when performing auto-approval, or strictly enforce data types (e.g., regex for colors) before trusting input.

--- a/functions/src/themes.ts
+++ b/functions/src/themes.ts
@@ -150,6 +150,24 @@ export const onThemeSubmitted = onDocumentWritten(
         }
       }
 
+      // Sentinel: Scan all theme values for CSS injection (url(), etc.)
+      // Any usage of url() in color fields constitutes an image/external
+      // resource and must be flagged for review to prevent privacy leaks
+      // or CSS injection.
+      for (const [key, value] of Object.entries(theme)) {
+        if (typeof value === "string") {
+          // Check for CSS url() syntax: url(...)
+          // This captures both url('...') and url("...") and url(...)
+          // Case-insensitive to catch URL(...) etc.
+          if (/url\s*\(/i.test(value)) {
+            logger.warn(
+                `Theme ${themeId} flagged: CSS url() detected in field ${key}.`,
+            );
+            hasImages = true;
+          }
+        }
+      }
+
       if (hasImages) {
         logger.info(`Theme ${themeId} requires review (contains images).`);
         return;

--- a/functions/src/themes_css_injection.test.ts
+++ b/functions/src/themes_css_injection.test.ts
@@ -1,0 +1,127 @@
+import {onThemeSubmitted} from "./themes";
+import * as admin from "firebase-admin";
+
+// --- Mocks Setup ---
+jest.mock("firebase-admin", () => {
+  const mSet = jest.fn().mockResolvedValue({});
+  const mDelete = jest.fn().mockResolvedValue({});
+  const mUpdate = jest.fn().mockResolvedValue({});
+  const mDoc = jest.fn().mockReturnValue({
+    set: mSet,
+    delete: mDelete,
+    update: mUpdate,
+  });
+  const mCollection = jest.fn().mockReturnValue({doc: mDoc});
+  const mRunTransaction = jest.fn().mockImplementation(async (cb: any) => {
+    const t = {
+      set: mSet,
+      delete: mDelete,
+    };
+    await cb(t);
+  });
+
+  const mFirestore: any = jest.fn().mockReturnValue({
+    collection: mCollection,
+    runTransaction: mRunTransaction,
+  });
+  mFirestore.FieldValue = {
+    serverTimestamp: jest.fn().mockReturnValue("TIMESTAMP"),
+  };
+
+  return {
+    firestore: mFirestore,
+    initializeApp: jest.fn(),
+    apps: [],
+  };
+});
+
+jest.mock("firebase-functions/v2/firestore", () => ({
+  onDocumentWritten: (trigger: string, handler: any) => handler,
+}));
+
+jest.mock("firebase-functions/logger", () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+}));
+
+describe("onThemeSubmitted CSS Injection", () => {
+  let firestoreMock: any;
+  let deleteMock: any;
+  let setMock: any;
+  let updateMock: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    firestoreMock = (admin.firestore as unknown as jest.Mock);
+    const db = firestoreMock();
+    const collection = db.collection();
+    const doc = collection.doc();
+    deleteMock = doc.delete;
+    setMock = doc.set;
+    updateMock = doc.update;
+  });
+
+  const createEvent = (data: any, exists = true) => ({
+    data: {
+      after: {
+        exists,
+        data: () => data,
+        ref: {delete: deleteMock, update: updateMock},
+      },
+    },
+    params: {themeId: "test-theme-css-1"},
+  });
+
+  it("should REQUIRE REVIEW/REJECT themes with CSS injection in color fields",
+      async () => {
+        const cssInjectionTheme = {
+          name: "CSS Injection Theme",
+          status: "pending",
+          theme: {
+            primaryColor: "url(http://attacker.com/pixel)",
+            // No explicit image fields like backgroundImageUrl
+          },
+        };
+        const event = createEvent(cssInjectionTheme);
+
+        await (onThemeSubmitted as any)(event);
+
+        // If vulnerability exists, it will auto-approve (setMock called)
+        // We want to ensure it DOES NOT auto-approve.
+        expect(setMock).not.toHaveBeenCalled();
+      });
+
+  it("should REQUIRE REVIEW/REJECT themes with CSS injection in bubble fields",
+      async () => {
+        const cssInjectionTheme = {
+          name: "CSS Injection Bubble",
+          status: "pending",
+          theme: {
+            bubbleIncoming:
+              "red; background-image: url(http://attacker.com/pixel);",
+          },
+        };
+        const event = createEvent(cssInjectionTheme);
+
+        await (onThemeSubmitted as any)(event);
+
+        expect(setMock).not.toHaveBeenCalled();
+      });
+
+  it("should REQUIRE REVIEW/REJECT themes with uppercase URL(...) injection",
+      async () => {
+        const cssInjectionTheme = {
+          name: "Uppercase CSS Injection",
+          status: "pending",
+          theme: {
+            primaryColor: "URL(http://attacker.com/pixel)",
+          },
+        };
+        const event = createEvent(cssInjectionTheme);
+
+        await (onThemeSubmitted as any)(event);
+
+        expect(setMock).not.toHaveBeenCalled();
+      });
+});


### PR DESCRIPTION
This PR addresses a "High" severity security vulnerability where attackers could inject CSS `url()` values into theme color fields (e.g., `primaryColor`) to bypass the "no images" auto-approval check.

**Vulnerability:**
The previous logic only checked specific fields (`backgroundImageUrl`, `iconOverrides`) for image URLs. Attackers could set `primaryColor: "url(http://attacker.com/tracking.png)"` which would be auto-approved and subsequently rendered by the frontend, causing privacy leaks (IP address) or potentially other CSS injection attacks.

**Fix:**
The `onThemeSubmitted` function in `functions/src/themes.ts` now iterates over *all* string values in the submitted theme object. If any value matches the case-insensitive regex `/url\s*\(/i`, the theme is flagged as `hasImages = true`, effectively preventing auto-approval and forcing manual review.

**Verification:**
- Added `functions/src/themes_css_injection.test.ts` which reproduces the issue (confirms auto-approval of malicious theme without fix) and verifies the fix (confirms no auto-approval with fix).
- Verified existing tests in `functions/src/themes_security.test.ts` pass.

**Sentinel Journal:**
- Added entry for "CSS Injection via Auto-Approval Bypass".

---
*PR created automatically by Jules for task [5954222869277441382](https://jules.google.com/task/5954222869277441382) started by @DamienLove*