### PR TITLE
Enable SMS Web Sync for Premium Users

### DIFF
--- a/androidApp/src/main/java/com/pulselink/data/messaging/FirebaseMessagingService.kt
+++ b/androidApp/src/main/java/com/pulselink/data/messaging/FirebaseMessagingService.kt
@@ -8,6 +8,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.pulselink.data.link.LinkChannelService
 import com.pulselink.data.sms.SmsRelayService
+import com.pulselink.data.sms.SmsSyncTrigger
 import com.pulselink.domain.repository.SettingsRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -21,6 +22,7 @@ class PulseLinkFirebaseMessagingService : FirebaseMessagingService() {
 
     @Inject lateinit var linkChannelService: LinkChannelService
     @Inject lateinit var smsRelayService: SmsRelayService
+    @Inject lateinit var smsSyncTrigger: SmsSyncTrigger
     @Inject lateinit var settingsRepository: SettingsRepository
     @Inject lateinit var firestore: FirebaseFirestore
     @Inject lateinit var auth: FirebaseAuth
@@ -38,6 +40,12 @@ class PulseLinkFirebaseMessagingService : FirebaseMessagingService() {
         Log.d(TAG, "Message received from: ${message.from}")
 
         val type = message.data["type"]
+        if (type == "SYNC_REQUEST") {
+            Log.d(TAG, "Received SYNC_REQUEST trigger")
+            smsSyncTrigger.triggerSync()
+            return
+        }
+
         if (type == "SMS_RELAY") {
             Log.d(TAG, "Received SMS_RELAY trigger")
             // Ensure the relay service is listening. This is idempotent.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,3 +34,4 @@ export {
 } from "./billing";
 export {getSpotifyAccessToken} from "./spotify";
 export {submitExtension, onExtensionSubmitted} from "./extensions";
+export {onUserUpdated} from "./sync";

--- a/functions/src/sync.ts
+++ b/functions/src/sync.ts
@@ -1,0 +1,66 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+export const onUserUpdated = functions.firestore
+    .document("users/{userId}")
+    .onUpdate(async (change, context) => {
+      const before = change.before.data();
+      const after = change.after.data();
+      const userId = context.params.userId;
+
+      // Check conditions for triggering sync
+      // 1. Remote Web Access just enabled
+      const webAccessEnabled = !before.remoteWebAccessEnabled && after.remoteWebAccessEnabled;
+
+      // 2. Explicit sync requested (timestamp changed)
+      // Use helper to safely compare Timestamps or numbers
+      const getMillis = (t: any) => t?.toMillis?.() ?? t ?? 0;
+      const syncRequested = getMillis(before.syncRequestedAt) !== getMillis(after.syncRequestedAt);
+
+      // 3. Premium Activated
+      const premiumActivated = before.premiumSubscriptionStatus !== "SUBSCRIPTION_STATE_ACTIVE" &&
+                               after.premiumSubscriptionStatus === "SUBSCRIPTION_STATE_ACTIVE";
+
+      if (webAccessEnabled || syncRequested || premiumActivated) {
+        console.log(`Triggering SMS sync for user ${userId} (web=${webAccessEnabled}, sync=${syncRequested}, premium=${premiumActivated})`);
+
+        const db = admin.firestore();
+        const devicesQuery = await db.collection("devices").where("uid", "==", userId).get();
+
+        if (devicesQuery.empty) {
+          console.log(`No devices found for user ${userId}`);
+          return;
+        }
+
+        const tokens: string[] = [];
+        devicesQuery.forEach((doc) => {
+          const data = doc.data();
+          if (data.fcmToken) {
+            tokens.push(data.fcmToken);
+          }
+        });
+
+        if (tokens.length === 0) {
+          console.log(`No FCM tokens found for user ${userId}`);
+          return;
+        }
+
+        const payload = {
+          data: {
+            type: "SYNC_REQUEST",
+            timestamp: String(Date.now()),
+          },
+          tokens: tokens,
+          android: {
+            priority: "high" as const,
+          },
+        };
+
+        try {
+          const response = await admin.messaging().sendMulticast(payload);
+          console.log(`Sent SYNC_REQUEST to ${response.successCount} devices for user ${userId}`);
+        } catch (error) {
+          console.error("Error sending SYNC_REQUEST", error);
+        }
+      }
+    });


### PR DESCRIPTION
This change enables the "Web Access to Messages" feature for premium users by implementing the synchronization trigger loop.

When a user enables "Remote Web Access" in the web UI (or upgrades to Premium), a Cloud Function (`onUserUpdated`) now sends a high-priority FCM message (`SYNC_REQUEST`) to the user's Android device. The Android app intercepts this message and initiates the `SmsSyncWorker` (via `SmsSyncTrigger`), which uploads SMS messages to Firestore. The web UI, which already listens to Firestore, then displays the messages.

Changes:
- Added `functions/src/sync.ts`
- Modified `functions/src/index.ts`
- Modified `androidApp/src/main/java/com/pulselink/data/messaging/FirebaseMessagingService.kt`

---
*PR created automatically by Jules for task [17271358276886630655](https://jules.google.com/task/17271358276886630655) started by @DamienLove*