### PR TITLE
Fix issues #534, #362, and #476 (Vibrations, Bug Report, iOS Build)

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
@@ -1644,13 +1644,14 @@ class MainActivity : AppCompatActivity() {
                         } else {
                             "Custom audio"
                         }
-                        val messageVibrationLabel = VibrationPatterns
-                            .messageOption(state.settings.messageNotificationVibrationPattern)
-                            .label
                         val customVibration = VibrationPatterns.customOption(
                             state.settings.customVibrationPatternName,
                             state.settings.customVibrationPattern
                         )
+                        val messageVibrationLabel = (
+                            customVibration.takeIf { state.settings.messageNotificationVibrationPattern == VibrationPatterns.CUSTOM_KEY }
+                                ?: VibrationPatterns.messageOption(state.settings.messageNotificationVibrationPattern)
+                            ).label
                         val emergencyVibrationLabel = (
                             customVibration.takeIf { state.settings.emergencyProfile.vibrationPatternKey == VibrationPatterns.CUSTOM_KEY }
                                 ?: VibrationPatterns.alertOption(state.settings.emergencyProfile.vibrationPatternKey)

--- a/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
@@ -1521,6 +1521,8 @@ class MainViewModel @Inject constructor(
         // Direct to GitHub issue form so users land on the correct bug report page.
         return Uri.parse(BUG_REPORT_PAGE_URL)
             .buildUpon()
+            .appendQueryParameter("template", "bug_report.md")
+            .appendQueryParameter("labels", "bug")
             .appendQueryParameter("title", subjectSuffix)
             .appendQueryParameter("body", formattedBody)
             .build()

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -20,7 +20,7 @@ targets:
           - "**/*.xcworkspace"
           - "**/*.xcuserstate"
     settings:
-      PRODUCT_BUNDLE_IDENTIFIER: com.pulselink.ios.free
+      PRODUCT_BUNDLE_IDENTIFIER: com.pulselink.ios
       INFOPLIST_FILE: PulseLinkiOS/Info.plist
       INFOPLIST_KEY_CFBundleDisplayName: PulseLink
 


### PR DESCRIPTION
Addressed three specific issues reported on v144:
1.  **#534 Custom vibrations cant be set to use**: Fixed the UI label logic in `MainActivity.kt` which was incorrectly falling back to "Default" for custom patterns because it didn't check for `VibrationPatterns.CUSTOM_KEY` in the message notification setting.
2.  **#362 Bug report page isnt going to the right page**: Updated `MainViewModel.kt` to include `template` and `labels` query parameters in the GitHub URL, ensuring the bug report template is pre-filled.
3.  **#476 IOS Build Failed in codemagic**: Corrected the `PulseLinkFree` bundle identifier in `iosApp/project.yml` to `com.pulselink.ios` to match the `GoogleService-Info.plist` configuration, which fixes the Firebase capability mismatch during build/signing.

---
*PR created automatically by Jules for task [6231310866986535534](https://jules.google.com/task/6231310866986535534) started by @DamienLove*