### PR TITLE
Fix Pro widget and improve bug reporting visibility

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
@@ -956,6 +956,7 @@ class MainActivity : AppCompatActivity() {
                             onViewEmergencyMap = { navController.navigate("emergency_map") },
                             isCancelingEmergency = isCancelingEmergency,
                             onAlertsClick = { navController.navigate("alerts_history") { launchSingleTop = true } },
+                            onReportBug = { navController.navigate("bug_report") { launchSingleTop = true } },
                             showAddLoginPrompt = isSmsOnlyUser,
                             onAddLoginClick = {
                                 navController.navigate("login") {
@@ -1302,6 +1303,7 @@ class MainActivity : AppCompatActivity() {
                             onSendCheckIn = viewModel::sendCheckIn,
                             onSettingsClick = { navController.navigate("settings") { launchSingleTop = true } },
                             onFaqClick = { navController.navigate("faq") { launchSingleTop = true } },
+                            onReportBug = { navController.navigate("bug_report") { launchSingleTop = true } },
                             onBeaconClick = launchBeaconInbox,
                             onOpenContacts = {
                                 navController.navigate("sms/inbox?filter=contacts") {

--- a/androidApp/src/main/java/com/pulselink/ui/screens/HomeScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/HomeScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Call
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
@@ -152,6 +153,7 @@ fun HomeScreen(
     onAlertsClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
     onFaqClick: () -> Unit = {},
+    onReportBug: () -> Unit = {},
     onBeaconClick: () -> Unit = {},
     onOpenContacts: () -> Unit = {},
     onOpenNotifications: () -> Unit = {},
@@ -264,6 +266,7 @@ fun HomeScreen(
                 onAlertsClick = onAlertsClick,
                 onSettingsClick = onSettingsClick,
                 onFaqClick = onFaqClick,
+                onReportBug = onReportBug,
                 onBeaconClick = onBeaconClick,
                 onUpgradeClick = onUpgradeClick,
                 showBeacon = showBeaconIcon || isUnifiedMode,
@@ -415,6 +418,7 @@ private fun HeaderSection(
     onAlertsClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onFaqClick: () -> Unit,
+    onReportBug: () -> Unit,
     onBeaconClick: () -> Unit,
     onUpgradeClick: () -> Unit,
     showBeacon: Boolean,
@@ -480,6 +484,7 @@ private fun HeaderSection(
                     onAlertsClick = onAlertsClick,
                     onSettingsClick = onSettingsClick,
                     onFaqClick = onFaqClick,
+                    onReportBug = onReportBug,
                     onBeaconClick = onBeaconClick,
                     onNotificationsClick = onOpenNotifications,
                     onThemesClick = onOpenThemes,
@@ -738,6 +743,7 @@ private fun NavigationRow(
     onAlertsClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onFaqClick: () -> Unit,
+    onReportBug: () -> Unit,
     onBeaconClick: () -> Unit,
     onNotificationsClick: () -> Unit,
     onThemesClick: () -> Unit,
@@ -761,6 +767,7 @@ private fun NavigationRow(
             compact = compact
         )
         NavButton(icon = Icons.Filled.Help, label = stringResource(id = R.string.faq_title), onClick = onFaqClick, compact = compact)
+        NavButton(icon = Icons.Filled.BugReport, label = stringResource(id = R.string.action_report_bug), onClick = onReportBug, compact = compact)
         NavButton(icon = Icons.Filled.NotificationsActive, label = "Tones", onClick = onNotificationsClick, compact = compact)
         NavButton(icon = Icons.Filled.Palette, label = "Themes", onClick = onThemesClick, compact = compact)
         if (showBeacon) {

--- a/androidApp/src/main/java/com/pulselink/ui/screens/UnifiedHomeScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/UnifiedHomeScreen.kt
@@ -72,6 +72,7 @@ fun UnifiedHomeScreen(
     onViewEmergencyMap: () -> Unit,
     isCancelingEmergency: Boolean,
     onAlertsClick: () -> Unit,
+    onReportBug: () -> Unit,
     showAddLoginPrompt: Boolean,
     onAddLoginClick: () -> Unit,
     showWebAccessHint: Boolean,
@@ -164,6 +165,7 @@ fun UnifiedHomeScreen(
         onSendCheckIn = onSendCheckIn,
         onSettingsClick = onSettingsClick,
         onFaqClick = onFaqClick,
+        onReportBug = onReportBug,
         onBeaconClick = onViewAllMessages, // Redirect Beacon header click to full inbox
         onOpenContacts = onOpenContacts,
         onOpenNotifications = onOpenNotifications,

--- a/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
@@ -1523,6 +1523,7 @@ class MainViewModel @Inject constructor(
             .buildUpon()
             .appendQueryParameter("title", subjectSuffix)
             .appendQueryParameter("body", formattedBody)
+            .appendQueryParameter("labels", "bug")
             .build()
     }
 

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="action_save">Save</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_back">Back</string>
+    <string name="action_report_bug">Report</string>
     <string name="notification_title_alert">PulseLink alert active</string>
     <string name="notification_body_alert">Alert dispatched to your circle.</string>
     <string name="notification_title_alert_sent">Emergency alert sent</string>

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -6,28 +6,6 @@
         <provider
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
-
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
This PR addresses two issues:
1.  **Missing Widget on Pro:** The `PulseLinkWidgetProvider` was duplicated in `androidApp/src/pro/AndroidManifest.xml`, effectively shadowing or conflicting with the main manifest during merge. Removed the duplicate to allow proper inheritance.
2.  **Bug Reporting Usability:** 
    - Added a prominent "Report Bug" button to the main navigation row in `HomeScreen`.
    - Wired the navigation logic in `MainActivity` and `UnifiedHomeScreen`.
    - Updated `MainViewModel` to auto-label issues as `bug` when generating the GitHub URL.
    - Added localized string `action_report_bug`.

---
*PR created automatically by Jules for task [11457410607371812443](https://jules.google.com/task/11457410607371812443) started by @DamienLove*