### PR TITLE
⚡ Bolt: Optimize contact sync and thread rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-27 - Array Allocation in Render Loops
 **Learning:** `[...a, ...b].filter(Boolean).join(' • ')` is a common pattern for joining strings with separators, but it creates multiple intermediate arrays (spread, filter result) on every render.
 **Action:** For simple string joining in hot paths (like list items), use imperative string concatenation or template literals to avoid unnecessary object allocation.
+
+## 2024-05-28 - Firestore Snapshot Optimization in React
+**Learning:** Naive `snapshot.docs.map()` in Firestore listeners creates new object references for *every* document on every update, breaking `React.memo` downstream even for unchanged items.
+**Action:** Use `snapshot.docChanges()` with a local `Map` cache inside the `useEffect` closure to maintain stable object references for unchanged documents, significantly reducing re-renders in large lists.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -168,18 +168,29 @@ const Avatar = memo(({ name, url, size = 40, style, className = "thread-avatar" 
 Avatar.displayName = 'Avatar';
 
 const areThreadsEqual = (prev, next) => {
-  return prev.isActive === next.isActive &&
+  const basicMatch = prev.isActive === next.isActive &&
          prev.showPreviews === next.showPreviews &&
          prev.onSelect === next.onSelect &&
          prev.onPin === next.onPin &&
          prev.onArchive === next.onArchive &&
-         prev.contactLookup === next.contactLookup &&
          prev.thread.id === next.thread.id &&
          prev.thread.address === next.thread.address &&
          prev.thread.snippet === next.thread.snippet &&
          prev.thread.display_name === next.thread.display_name &&
          prev.thread.pinned === next.thread.pinned &&
          prev.thread.archived === next.thread.archived;
+
+  if (!basicMatch) return false;
+
+  // Bolt: Optimized to prevent re-render if contactLookup changed
+  // but the resolved contact for this thread is the same (reference equal).
+  if (prev.contactLookup === next.contactLookup) return true;
+
+  const cleanPhone = (prev.thread.address || '').replace(/\D/g, '');
+  const prevContact = prev.contactLookup?.[cleanPhone];
+  const nextContact = next.contactLookup?.[cleanPhone];
+
+  return prevContact === nextContact;
 };
 
 // Bolt: Optimized ThreadItem with memo to prevent unnecessary re-renders of the entire list
@@ -2802,13 +2813,26 @@ function App() {
       return;
     }
     const deviceRef = collection(db, "users", user.uid, "deviceContacts");
+    // Bolt: Use local cache to maintain stable object references for unchanged contacts
+    const localCache = new Map();
     const unsubscribe = onSnapshot(deviceRef, (snapshot) => {
-      const items = snapshot.docs.map(docSnap => ({
-        id: docSnap.id,
-        ...docSnap.data()
-      }));
-      items.sort((a, b) => (a.displayName ?? '').localeCompare(b.displayName ?? ''));
-      setDeviceContacts(items);
+      let changed = false;
+      snapshot.docChanges().forEach((change) => {
+        if (change.type === 'added' || change.type === 'modified') {
+          localCache.set(change.doc.id, { id: change.doc.id, ...change.doc.data() });
+          changed = true;
+        }
+        if (change.type === 'removed') {
+          localCache.delete(change.doc.id);
+          changed = true;
+        }
+      });
+
+      if (changed) {
+        const items = Array.from(localCache.values());
+        items.sort((a, b) => (a.displayName ?? '').localeCompare(b.displayName ?? ''));
+        setDeviceContacts(items);
+      }
     });
     return () => unsubscribe();
   }, [user]);


### PR DESCRIPTION
💡 What: Optimized Firestore `deviceContacts` synchronization to use `snapshot.docChanges()` with a local cache, and refined `ThreadItem`'s `React.memo` comparator.
🎯 Why: Previously, every Firestore update (even single doc changes) recreated all contact objects, causing `contactLookup` to rebuild and forcing ALL `ThreadItem` components to re-render.
📊 Impact: drastically reduces re-renders during contact sync (O(1) vs O(N) object creation, O(1) vs O(N) component re-renders for single updates).
🔬 Measurement: Verified with `pnpm lint` and build checks. Logic ensures stable object references are passed to memoized components.

---
*PR created automatically by Jules for task [9365775799648733380](https://jules.google.com/task/9365775799648733380) started by @DamienLove*