### PR TITLE
Fix manifest merge conflicts, bug report labels, and email intent handling

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/screens/ContactDetailScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/ContactDetailScreen.kt
@@ -279,7 +279,9 @@ private fun LinkStatusSection(
                                     // Use ACTION_SENDTO with encoded mailto URI to ensure subject/body are populated in all clients
                                     // Also put extras directly for clients that ignore URI params (e.g. Gmail)
                                     val emailIntent = Intent(Intent.ACTION_SENDTO).apply {
-                                        data = Uri.parse("mailto:${contact.email ?: ""}")
+                                        val uriString = EmailUtils.createMailtoUriString(contact.email, rawSubject, rawBody)
+                                        data = Uri.parse(uriString)
+                                        // Keep extras for redundancy/compatibility
                                         putExtra(Intent.EXTRA_SUBJECT, rawSubject)
                                         putExtra(Intent.EXTRA_TEXT, rawBody)
                                     }

--- a/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
@@ -1523,6 +1523,7 @@ class MainViewModel @Inject constructor(
             .buildUpon()
             .appendQueryParameter("title", subjectSuffix)
             .appendQueryParameter("body", formattedBody)
+            .appendQueryParameter("labels", "bug")
             .build()
     }
 

--- a/androidApp/src/premium/AndroidManifest.xml
+++ b/androidApp/src/premium/AndroidManifest.xml
@@ -8,27 +8,7 @@
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
 
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
+        <!-- Home screen widget (available in all flavors, incl. Pro) - Inherited from main -->
     </application>
 
 </manifest>

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -7,27 +7,7 @@
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
 
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
+        <!-- Home screen widget (available in all flavors, incl. Pro) - Inherited from main -->
     </application>
 
 </manifest>


### PR DESCRIPTION
*   Resolved Issue #76: Removed redundant `PulseLinkWidgetProvider`, `PulseLinkWidgetActionReceiver`, and `PulseLinkWidgetService` definitions from `pro` and `premium` flavor manifests to prevent merge conflicts and ensure widget availability in all flavors.
*   Resolved Issue #77: Updated `MainViewModel.kt` to append `labels=bug` to the generated GitHub bug report URI, ensuring issues are correctly labeled upon submission.
*   Resolved Issue #66: Updated `ContactDetailScreen.kt` to use `EmailUtils.createMailtoUriString` when constructing the `ACTION_SENDTO` intent, ensuring the subject and body are correctly populated in all email clients (including those that ignore extras).
*   Verified with unit tests (`testProDebugUnitTest`, `testPremiumDebugUnitTest`).

---
*PR created automatically by Jules for task [2947285896227862492](https://jules.google.com/task/2947285896227862492) started by @DamienLove*