### PR TITLE
Make contacts list interactive for messaging

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-28 - Image Load Error Fallbacks
 **Learning:** User-provided URLs for avatars often break (404s), resulting in ugly browser-default broken image icons that degrade perceived app quality. Relying solely on "if URL exists" logic is insufficient.
 **Action:** Implemented a `useState` + `onError` handler pattern in the `Avatar` component to detect load failures and automatically revert to the deterministic initial fallback, maintaining UI elegance even with bad data.
+
+## 2024-05-29 - Broken UX Promises: Hover vs. Action
+**Learning:** Elements with distinct hover states (like list rows) create an expectation of interactivity. When they are static (read-only), users feel "blocked" or "teased."
+**Action:** Audit list items for hover styles; if present, ensure the item is interactive (e.g., opens details or selection) or remove the hover style to match the static behavior.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -273,6 +273,7 @@ MessageItem.displayName = 'MessageItem';
 
 // Bolt: Custom comparator for DeviceContactItem to handle object reference changes
 const areDeviceContactsEqual = (prev, next) => {
+  if (prev.onSelect !== next.onSelect) return false;
   const p = prev.contact;
   const n = next.contact;
   if (p === n) return true; // Reference equality
@@ -312,7 +313,7 @@ const areDeviceContactsEqual = (prev, next) => {
 };
 
 // Bolt: Optimized DeviceContactItem to prevent re-renders of the large contact list
-const DeviceContactItem = memo(({ contact }) => {
+const DeviceContactItem = memo(({ contact, onSelect }) => {
   // Bolt: Optimized to avoid array allocation during render
   let extras = '';
   if (Array.isArray(contact.additionalPhones)) {
@@ -333,7 +334,19 @@ const DeviceContactItem = memo(({ contact }) => {
   }
 
   return (
-    <div className="contact-row contact-row--stacked">
+    <div
+      className="contact-row contact-row--stacked"
+      onClick={() => onSelect && onSelect(contact)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          if (onSelect) onSelect(contact);
+        }
+      }}
+      aria-label={`Message ${contact.displayName || 'contact'}`}
+    >
       <div className="contact-main">
         <div className="contact-name">{contact.displayName || 'Unnamed contact'}</div>
         <div className="contact-meta">
@@ -2540,12 +2553,23 @@ function App() {
     ))
   ), [messages, showPreviews]);
 
+  // Bolt: Stable handler for starting a thread from contact list
+  const handleContactSelect = useCallback((contact) => {
+    setActivePanel('beacon');
+    setSelectedThread({
+      id: `new_${contact.id}`,
+      address: contact.phoneNumber,
+      display_name: contact.displayName,
+      isTemp: true
+    });
+  }, []);
+
   // Bolt: Pagination for contact list to improve performance
   const contactListElements = useMemo(() => (
     filteredDeviceContacts.slice(0, contactListLimit).map((contact) => (
-      <DeviceContactItem key={contact.id} contact={contact} />
+      <DeviceContactItem key={contact.id} contact={contact} onSelect={handleContactSelect} />
     ))
-  ), [filteredDeviceContacts, contactListLimit]);
+  ), [filteredDeviceContacts, contactListLimit, handleContactSelect]);
 
   useEffect(() => {
     // Bolt: Mock user support for Playwright testing

--- a/web/tests/contacts_interaction.spec.js
+++ b/web/tests/contacts_interaction.spec.js
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Contacts Interaction', () => {
+  test.beforeEach(async ({ page }) => {
+    // Enable mock user mode to get pre-populated contacts
+    await page.goto('/?mock_user=true');
+    // Wait for initial load
+    await page.waitForTimeout(2000);
+  });
+
+  test('clicking a device contact should open composer with that contact', async ({ page }) => {
+    // 1. Navigate to Contacts panel
+    // Wait for the home grid to appear
+    await expect(page.locator('.home-grid')).toBeVisible();
+
+    // Click the Contacts card on Home
+    // Use a more robust selector if possible, but h3 text works for now based on App.jsx
+    await page.locator('.home-card:has(h3:text("Contacts"))').click();
+
+    // 2. Verify we are in Contacts panel
+    await expect(page.locator('.contacts-panel')).toBeVisible();
+
+    // 3. Find a contact item. Mock user usually has "Alice"
+    // The mock data setup in App.jsx:
+    // setDeviceContacts([{ id: 'dev_1', displayName: 'Alice', phoneNumber: '+15553334444' }]);
+    const contactItem = page.locator('.contact-row', { hasText: 'Alice' }).first();
+    await expect(contactItem).toBeVisible();
+
+    // Verify it has accessibility attributes
+    await expect(contactItem).toHaveAttribute('role', 'button');
+    await expect(contactItem).toHaveAttribute('tabindex', '0');
+
+    // 4. Click the contact
+    await contactItem.click();
+
+    // 5. Verify we are redirected to Beacon (messaging)
+    // The active panel switches to 'beacon'.
+    // We can verify the presence of the composer.
+    const composer = page.locator('.composer');
+    await expect(composer).toBeVisible();
+
+    // 6. Verify the 'To' field is populated with the contact's number
+    const toInput = page.locator('#compose-address');
+    await expect(toInput).toHaveValue('+15553334444');
+  });
+});


### PR DESCRIPTION
This PR updates the "Contacts" panel in the web interface to make contact items interactive. Previously, they were static display elements. Now, clicking a contact (or pressing Enter/Space) opens the Beacon messaging panel with the contact's number pre-filled in the composer. This improves the UX by fulfilling the user expectation that list items are actionable.

**Changes:**
- `web/src/App.jsx`:
    - `DeviceContactItem`: Added `onClick`, `onKeyDown`, `role="button"`, `tabIndex="0"`, and `aria-label`.
    - `areDeviceContactsEqual`: Added check for `onSelect` prop.
    - `App` component: Added `handleContactSelect` and threaded it to `DeviceContactItem`.
- `web/tests/contacts_interaction.spec.js`: Added new Playwright test.

**Accessibility:**
- Added keyboard support (Enter/Space) to contact items.
- Added `role="button"` and correct `tabIndex`.
- Added descriptive `aria-label`.

---
*PR created automatically by Jules for task [3247747424063796659](https://jules.google.com/task/3247747424063796659) started by @DamienLove*