### PR TITLE
⚡ Bolt: Optimize date formatting allocations

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -264,7 +264,7 @@ const MessageItem = memo(({ msg, showPreviews }) => (
       {showPreviews ? msg.body : '••••••'}
     </div>
     <div className="message-time">
-      {timeFormatter.format(new Date(msg.date))}
+      {timeFormatter.format(msg.date)}
     </div>
   </div>
 ), areMessagesEqual);
@@ -460,7 +460,7 @@ const MapAlertItem = memo(({ alert, isActive, onFocus, onClear }) => {
           {alertBadgeCopy[alert.severity] ?? 'Alert'}
         </span>
       </div>
-      <div className="map-item-meta">{dateTimeFormatter.format(new Date(alert.date))}</div>
+      <div className="map-item-meta">{dateTimeFormatter.format(alert.date)}</div>
       <div className="map-item-snippet">{buildAlertSnippet(alert.body)}</div>
       <div className="map-item-actions">
         <button
@@ -3119,7 +3119,7 @@ function App() {
         // Sentinel: Escape user input to prevent XSS in InfoWindow
         const safeType = escapeHtml(alertBadgeCopy[alert.severity] ?? 'Alert');
         const safeAddress = escapeHtml(alert.address);
-        const safeDate = escapeHtml(dateTimeFormatter.format(new Date(alert.date)));
+        const safeDate = escapeHtml(dateTimeFormatter.format(alert.date));
 
         mapInfoRef.current.setContent(
           `<div style="font-family: sans-serif; max-width: 220px;">
@@ -3170,7 +3170,7 @@ function App() {
       // Sentinel: Escape user input to prevent XSS in InfoWindow
       const safeType = escapeHtml(alertBadgeCopy[alert.severity] ?? 'Alert');
       const safeAddress = escapeHtml(alert.address);
-      const safeDate = escapeHtml(dateTimeFormatter.format(new Date(alert.date)));
+      const safeDate = escapeHtml(dateTimeFormatter.format(alert.date));
 
       mapInfoRef.current.setContent(
         `<div style="font-family: sans-serif; max-width: 220px;">
@@ -5151,7 +5151,7 @@ function App() {
                             <span className="settings-label">Web sync</span>
                             <span className="settings-value">
                               {syncDiagnostics
-                                ? `${dateTimeFormatter.format(new Date(toMillis(syncDiagnostics.timestamp)))} • ${syncDiagnostics.status}`
+                                ? `${dateTimeFormatter.format(toMillis(syncDiagnostics.timestamp))} • ${syncDiagnostics.status}`
                                 : 'No sync data yet'}
                             </span>
                           </div>
@@ -5164,7 +5164,7 @@ function App() {
                             <span className="settings-label">Relay status</span>
                             <span className="settings-value">
                               {relayDiagnostics
-                                ? `${dateTimeFormatter.format(new Date(toMillis(relayDiagnostics.timestamp)))} • ${relayDiagnostics.status}`
+                                ? `${dateTimeFormatter.format(toMillis(relayDiagnostics.timestamp))} • ${relayDiagnostics.status}`
                                 : 'No relay data yet'}
                             </span>
                           </div>


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

💡 What:
Replaced `timeFormatter.format(new Date(timestamp))` with `timeFormatter.format(timestamp)` in `web/src/App.jsx`.

🎯 Why:
`Intl.DateTimeFormat.prototype.format` accepts a timestamp (number) directly. Creating a `new Date()` object is redundant and adds unnecessary garbage collection overhead, especially in large lists like the message inbox or alert map.

📊 Impact:
Reduces object allocation per rendered item in lists. For a list of 100 messages, this saves 100 Date object allocations per render cycle where the list is processed.

🔬 Measurement:
Verified via `pnpm lint` and `pnpm build`. Functional verification via Playwright tests (`beacon_inbox.spec.js`) passed.

---
*PR created automatically by Jules for task [10982963282577465010](https://jules.google.com/task/10982963282577465010) started by @DamienLove*