### PR TITLE
Configure iOS Entitlements and Targets

### DIFF
--- a/iosApp/BeaconiOS/Beacon.entitlements
+++ b/iosApp/BeaconiOS/Beacon.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/iosApp/PulseLinkiOS/PulseLink.entitlements
+++ b/iosApp/PulseLinkiOS/PulseLink.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
+</dict>
+</plist>

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -14,6 +14,7 @@ targets:
   PulseLinkFree:
     type: application
     platform: iOS
+    entitlements: PulseLinkiOS/PulseLink.entitlements
     sources:
       - path: PulseLinkiOS
         excludes:
@@ -27,6 +28,7 @@ targets:
   PulseLinkPro:
     type: application
     platform: iOS
+    entitlements: PulseLinkiOS/PulseLink.entitlements
     sources:
       - path: PulseLinkiOS
         excludes:
@@ -41,6 +43,7 @@ targets:
   BeaconFree:
     type: application
     platform: iOS
+    entitlements: BeaconiOS/Beacon.entitlements
     sources:
       - path: BeaconiOS
     settings:
@@ -51,6 +54,7 @@ targets:
   BeaconPro:
     type: application
     platform: iOS
+    entitlements: BeaconiOS/Beacon.entitlements
     sources:
       - path: BeaconiOS
     settings:


### PR DESCRIPTION
Updated `iosApp/project.yml` to link new entitlement files for PulseLink (Critical Alerts + Push) and Beacon (Push) targets. Verified targets (PulseLink Free/Pro, Beacon Free/Pro) exist and match Android functionality structure. Confirmed UI colors align with Android (v11/Laser Blue).

---
*PR created automatically by Jules for task [10754739528144804403](https://jules.google.com/task/10754739528144804403) started by @DamienLove*