### PR TITLE
🎨 Palette: Smart Focus in Message Composer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-28 - Image Load Error Fallbacks
 **Learning:** User-provided URLs for avatars often break (404s), resulting in ugly browser-default broken image icons that degrade perceived app quality. Relying solely on "if URL exists" logic is insufficient.
 **Action:** Implemented a `useState` + `onError` handler pattern in the `Avatar` component to detect load failures and automatically revert to the deterministic initial fallback, maintaining UI elegance even with bad data.
+
+## 2024-05-29 - Smart Focus Context Switching
+**Learning:** Users switching between "New Message" and existing threads expect different input focus targets (Recipient vs Body). Static focus management forces extra clicks.
+**Action:** Implemented a `useEffect` driven focus manager in `MessageComposer` that intelligently focuses the "To" field for new messages and the textarea for replies.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -720,6 +720,7 @@ const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeL
   const [status, setStatus] = useState('');
   const [isSending, setIsSending] = useState(false);
   const textareaRef = useRef(null);
+  const addressInputRef = useRef(null);
 
   useLayoutEffect(() => {
     const el = textareaRef.current;
@@ -732,10 +733,14 @@ const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeL
     if (selectedThread) {
       setAddress(selectedThread.address || '');
       setLineId(selectedThread.lineId || '');
+      // Smart Focus: Reply mode -> Focus body
+      textareaRef.current?.focus();
     } else {
       setAddress('');
       // When clearing (New message), reset lineId to empty to allow user selection or fallback
       setLineId('');
+      // Smart Focus: New message mode -> Focus address
+      addressInputRef.current?.focus();
     }
     setBody('');
     setStatus('');
@@ -793,6 +798,7 @@ const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeL
       <div className="composer-row">
         <label className="composer-label" htmlFor="compose-address">To<RequiredIndicator /></label>
         <input
+          ref={addressInputRef}
           id="compose-address"
           className="composer-input"
           type="tel"
@@ -834,6 +840,10 @@ const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeL
             onChange={(e) => setBody(e.target.value)}
             required
             onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                e.currentTarget.blur();
+              }
               if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
                 e.preventDefault();
                 handleSendMessage();

--- a/web/tests/composer_focus.spec.js
+++ b/web/tests/composer_focus.spec.js
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Message Composer Focus', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/?mock_user=true');
+    // Navigate to Beacon panel
+    await page.locator('.nav-item[title="Beacon"]').click();
+  });
+
+  test('should focus "To" input when switching to new message', async ({ page }) => {
+    // First, select a thread to ensure we are NOT in new message mode
+    await page.locator('.thread-item').first().click();
+    await expect(page.locator('.composer-textarea')).toBeFocused();
+
+    // Now Click "New" button in sidebar
+    await page.locator('button[aria-label="Start new conversation"]').click();
+
+    // Check if address input is focused
+    await expect(page.locator('#compose-address')).toBeFocused();
+  });
+
+  test('should focus message body when selecting a thread', async ({ page }) => {
+    // Click the first thread item
+    await page.locator('.thread-item').first().click();
+
+    // Check if textarea is focused
+    await expect(page.locator('.composer-textarea')).toBeFocused();
+  });
+
+  test('should blur message body when pressing Escape', async ({ page }) => {
+    // Select a thread to focus textarea
+    await page.locator('.thread-item').first().click();
+    await expect(page.locator('.composer-textarea')).toBeFocused();
+
+    // Press Escape
+    await page.keyboard.press('Escape');
+
+    // Check if textarea is NOT focused
+    await expect(page.locator('.composer-textarea')).not.toBeFocused();
+  });
+});


### PR DESCRIPTION
💡 What: Implemented context-aware focus management in the Message Composer.
🎯 Why: Users previously had to manually select the input field when switching between "New Message" (needs recipient) and "Reply" (needs body).
📸 Before/After: Verified visually that focus lands on "To" input for new messages and "Body" textarea for existing threads.
♿ Accessibility: Added Escape key handler to easily blur the textarea, improving keyboard navigation.

---
*PR created automatically by Jules for task [10470840189908042351](https://jules.google.com/task/10470840189908042351) started by @DamienLove*