### PR TITLE
fix: Resolve email link, bug report labels, and widget redundancy

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/screens/ContactDetailScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/ContactDetailScreen.kt
@@ -279,7 +279,8 @@ private fun LinkStatusSection(
                                     // Use ACTION_SENDTO with encoded mailto URI to ensure subject/body are populated in all clients
                                     // Also put extras directly for clients that ignore URI params (e.g. Gmail)
                                     val emailIntent = Intent(Intent.ACTION_SENDTO).apply {
-                                        data = Uri.parse("mailto:${contact.email ?: ""}")
+                                        val mailtoUri = EmailUtils.createMailtoUriString(contact.email, rawSubject, rawBody)
+                                        data = Uri.parse(mailtoUri)
                                         putExtra(Intent.EXTRA_SUBJECT, rawSubject)
                                         putExtra(Intent.EXTRA_TEXT, rawBody)
                                     }

--- a/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
@@ -1523,6 +1523,7 @@ class MainViewModel @Inject constructor(
             .buildUpon()
             .appendQueryParameter("title", subjectSuffix)
             .appendQueryParameter("body", formattedBody)
+            .appendQueryParameter("labels", "bug")
             .build()
     }
 

--- a/androidApp/src/premium/AndroidManifest.xml
+++ b/androidApp/src/premium/AndroidManifest.xml
@@ -8,27 +8,6 @@
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
 
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -7,27 +7,6 @@
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
 
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Addressed three reported issues:
1.  **Blank Email Composer (Issue #66):** Changed `ContactDetailScreen.kt` to use `EmailUtils.createMailtoUriString`. This ensures that the subject and body are properly encoded in the `mailto:` URI itself, which is required by some email clients (like Gmail) that ignore `Intent` extras when a `mailto:` URI is present.
2.  **Bug Report Labels (Issue #77):** Modified `MainViewModel.kt` to automatically append `labels=bug` to the generated GitHub issue URL, ensuring incoming reports are correctly categorized.
3.  **Widget Issues on Pro (Issue #76):** Identified and removed duplicate declarations of `PulseLinkWidgetProvider`, `PulseLinkWidgetActionReceiver`, and `PulseLinkWidgetService` in `androidApp/src/pro/AndroidManifest.xml` and `androidApp/src/premium/AndroidManifest.xml`. These components are already defined in `main`, and the duplicates were likely causing manifest merger conflicts or runtime issues.

---
*PR created automatically by Jules for task [1317183746444300496](https://jules.google.com/task/1317183746444300496) started by @DamienLove*