### PR TITLE
Fix issues #76, #66, #79: Manifest cleanup, Email link fix, Report Bug button

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
@@ -936,6 +936,7 @@ class MainActivity : AppCompatActivity() {
                             onSendCheckIn = viewModel::sendCheckIn,
                             onSettingsClick = { navController.navigate("settings") { launchSingleTop = true } },
                             onFaqClick = { navController.navigate("faq") { launchSingleTop = true } },
+                            onReportBugClick = { navController.navigate("bug_report") },
                             onOpenContacts = {
                                 navController.navigate("sms/inbox?filter=contacts") {
                                     launchSingleTop = true
@@ -1302,6 +1303,7 @@ class MainActivity : AppCompatActivity() {
                             onSendCheckIn = viewModel::sendCheckIn,
                             onSettingsClick = { navController.navigate("settings") { launchSingleTop = true } },
                             onFaqClick = { navController.navigate("faq") { launchSingleTop = true } },
+                            onReportBugClick = { navController.navigate("bug_report") },
                             onBeaconClick = launchBeaconInbox,
                             onOpenContacts = {
                                 navController.navigate("sms/inbox?filter=contacts") {

--- a/androidApp/src/main/java/com/pulselink/ui/screens/ContactDetailScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/ContactDetailScreen.kt
@@ -279,7 +279,7 @@ private fun LinkStatusSection(
                                     // Use ACTION_SENDTO with encoded mailto URI to ensure subject/body are populated in all clients
                                     // Also put extras directly for clients that ignore URI params (e.g. Gmail)
                                     val emailIntent = Intent(Intent.ACTION_SENDTO).apply {
-                                        data = Uri.parse("mailto:${contact.email ?: ""}")
+                                        data = Uri.parse(EmailUtils.createMailtoUriString(contact.email, rawSubject, rawBody))
                                         putExtra(Intent.EXTRA_SUBJECT, rawSubject)
                                         putExtra(Intent.EXTRA_TEXT, rawBody)
                                     }

--- a/androidApp/src/main/java/com/pulselink/ui/screens/HomeScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/HomeScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Call
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
@@ -152,6 +153,7 @@ fun HomeScreen(
     onAlertsClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
     onFaqClick: () -> Unit = {},
+    onReportBugClick: () -> Unit = {},
     onBeaconClick: () -> Unit = {},
     onOpenContacts: () -> Unit = {},
     onOpenNotifications: () -> Unit = {},
@@ -264,6 +266,7 @@ fun HomeScreen(
                 onAlertsClick = onAlertsClick,
                 onSettingsClick = onSettingsClick,
                 onFaqClick = onFaqClick,
+                onReportBugClick = onReportBugClick,
                 onBeaconClick = onBeaconClick,
                 onUpgradeClick = onUpgradeClick,
                 showBeacon = showBeaconIcon || isUnifiedMode,
@@ -415,6 +418,7 @@ private fun HeaderSection(
     onAlertsClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onFaqClick: () -> Unit,
+    onReportBugClick: () -> Unit,
     onBeaconClick: () -> Unit,
     onUpgradeClick: () -> Unit,
     showBeacon: Boolean,
@@ -480,6 +484,7 @@ private fun HeaderSection(
                     onAlertsClick = onAlertsClick,
                     onSettingsClick = onSettingsClick,
                     onFaqClick = onFaqClick,
+                    onReportBugClick = onReportBugClick,
                     onBeaconClick = onBeaconClick,
                     onNotificationsClick = onOpenNotifications,
                     onThemesClick = onOpenThemes,
@@ -738,6 +743,7 @@ private fun NavigationRow(
     onAlertsClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onFaqClick: () -> Unit,
+    onReportBugClick: () -> Unit,
     onBeaconClick: () -> Unit,
     onNotificationsClick: () -> Unit,
     onThemesClick: () -> Unit,
@@ -761,6 +767,7 @@ private fun NavigationRow(
             compact = compact
         )
         NavButton(icon = Icons.Filled.Help, label = stringResource(id = R.string.faq_title), onClick = onFaqClick, compact = compact)
+        NavButton(icon = Icons.Filled.BugReport, label = "Report", onClick = onReportBugClick, compact = compact)
         NavButton(icon = Icons.Filled.NotificationsActive, label = "Tones", onClick = onNotificationsClick, compact = compact)
         NavButton(icon = Icons.Filled.Palette, label = "Themes", onClick = onThemesClick, compact = compact)
         if (showBeacon) {

--- a/androidApp/src/main/java/com/pulselink/ui/screens/UnifiedHomeScreen.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/screens/UnifiedHomeScreen.kt
@@ -58,6 +58,7 @@ fun UnifiedHomeScreen(
     onSendCheckIn: () -> Unit,
     onSettingsClick: () -> Unit,
     onFaqClick: () -> Unit,
+    onReportBugClick: () -> Unit,
     onOpenContacts: () -> Unit,
     onOpenNotifications: () -> Unit,
     onOpenThemes: () -> Unit,
@@ -164,6 +165,7 @@ fun UnifiedHomeScreen(
         onSendCheckIn = onSendCheckIn,
         onSettingsClick = onSettingsClick,
         onFaqClick = onFaqClick,
+        onReportBugClick = onReportBugClick,
         onBeaconClick = onViewAllMessages, // Redirect Beacon header click to full inbox
         onOpenContacts = onOpenContacts,
         onOpenNotifications = onOpenNotifications,

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -6,28 +6,6 @@
         <provider
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
-
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
- Issue #76: Removed duplicate widget provider declarations from `pro` and `free` flavor manifests to fix build/merge warnings and potential conflicts.
- Issue #66: Updated `ContactDetailScreen` to use `EmailUtils.createMailtoUriString` for correctly encoding email links with subject and body.
- Issue #79: Added a "Report" button to the `HomeScreen` navigation header (and `UnifiedHomeScreen`) to make bug reporting more accessible.
- Verified compilation and relevant logic.

---
*PR created automatically by Jules for task [7278076551591825643](https://jules.google.com/task/7278076551591825643) started by @DamienLove*