### PR TITLE
Beacon Inbox: Newest First & Optimistic Updates

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -713,7 +713,7 @@ const SpotifyResultItem = memo(({ track, onAdd, isAdding }) => (
 SpotifyResultItem.displayName = 'SpotifyResultItem';
 
 // Bolt: MessageComposer extracted to prevent App re-renders on typing
-const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeLineId, lines, isLoggingIn }) => {
+const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeLineId, lines, isLoggingIn, onMessageSent }) => {
   const [address, setAddress] = useState('');
   const [body, setBody] = useState('');
   const [lineId, setLineId] = useState('');
@@ -754,6 +754,19 @@ const MessageComposer = memo(({ user, db, selectedThread, lineInboxMode, activeL
     setIsSending(true);
     setStatus('');
     try {
+      // Optimistic update via parent callback
+      const tempId = `temp_${Date.now()}`;
+      if (onMessageSent) {
+        onMessageSent({
+          id: tempId,
+          body: cleanBody,
+          address: cleanAddress,
+          date: Date.now(),
+          type: 2, // Sent
+          lineId: effectiveLineId
+        });
+      }
+
       const docRef = await addDoc(collection(db, "users", user.uid, "outbox"), {
         address: cleanAddress,
         body: cleanBody,
@@ -2903,8 +2916,8 @@ function App() {
         ? ["users", user.uid, "lines", selectedThread.lineId, "threads", selectedThread.id, "messages"]
         : ["users", user.uid, "synced_threads", selectedThread.id, "messages"];  
       const messagesRef = collection(db, ...basePath);
-      // Bolt: Standard chat order (Oldest -> Newest)
-      const q = query(messagesRef, orderBy("date", "asc"));
+      // Bolt: Reverse chat order (Newest -> Oldest)
+      const q = query(messagesRef, orderBy("date", "desc"));
       const unsubscribe = onSnapshot(q, (snapshot) => {
         const messagesData = snapshot.docs.map(doc => {
           const data = doc.data();
@@ -2923,12 +2936,8 @@ function App() {
   }, [user, selectedThread]);
 
 
-  // Bolt: Auto-scroll to bottom when new messages arrive
-  useEffect(() => {
-    if (autoScroll && messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [messages, autoScroll, selectedThread]);
+  // Bolt: Auto-scroll removed for reverse chronological order (Newest First)
+  // New messages appear at the top, so user is already at the correct position.
 
   useEffect(() => {
     if (new URLSearchParams(window.location.search).get('mock_user') === 'true') return;
@@ -3783,6 +3792,30 @@ function App() {
       setActiveLineId((prev) => prev ?? thread.lineId);
     }
   }, []);
+
+  const handleMessageSent = useCallback((msg) => {
+    // 1. Add to messages list (at top)
+    setMessages(prev => [msg, ...prev]);
+
+    // 2. Update thread snippet/date in sidebar optimistically
+    const updateThread = (t) => {
+      if (t.address === msg.address || t.id === selectedThread?.id) {
+        return { ...t, snippet: msg.body, date: msg.date };
+      }
+      return t;
+    };
+
+    if (msg.lineId) {
+        setLineThreads(prev => {
+            const lineList = prev[msg.lineId] || [];
+            // If thread exists, update it. If not, we might need to create it locally (complex),
+            // but for existing thread it's simple.
+            return { ...prev, [msg.lineId]: lineList.map(updateThread) };
+        });
+    } else {
+        setLegacyThreads(prev => prev.map(updateThread));
+    }
+  }, [selectedThread]);
 
   const handlePinThread = useCallback(async (thread) => {
     if (!user) return;
@@ -5265,7 +5298,6 @@ function App() {
                     </div>
                     <div className="messages-list">
                       {messageListElements}
-                      <div ref={messagesEndRef} style={{ height: 1 }} />
                     </div>
                     <MessageComposer
                       user={user}
@@ -5275,6 +5307,7 @@ function App() {
                       activeLineId={activeLineId}
                       lines={lines}
                       isLoggingIn={isLoggingIn}
+                      onMessageSent={handleMessageSent}
                     />
                   </>
                 ) : (
@@ -5289,6 +5322,7 @@ function App() {
                         activeLineId={activeLineId}
                         lines={lines}
                         isLoggingIn={isLoggingIn}
+                        onMessageSent={handleMessageSent}
                     />
                   </div>
                 )}

--- a/web/test-results/.last-run.json
+++ b/web/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/web/tests/beacon_message_order.spec.js
+++ b/web/tests/beacon_message_order.spec.js
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Beacon Message Ordering', () => {
+  test.beforeEach(async ({ page }) => {
+    // Enable mock user mode
+    await page.goto('/?mock_user=true');
+    // Navigate to Beacon Inbox
+    await page.locator('.home-card h3', { hasText: 'Beacon Inbox' }).click();
+    // Wait for thread list
+    await expect(page.locator('.thread-item').first()).toBeVisible();
+  });
+
+  test('should display messages in reverse chronological order (newest at top)', async ({ page }) => {
+    // Select the first thread
+    await page.locator('.thread-item').first().click();
+
+    // Inject messages in the order Firestore would return them (Newest First)
+    // Since App.jsx relies on Firestore sorting, we simulate that here.
+    await page.evaluate(() => {
+        const now = Date.now();
+        const messages = [
+            { id: 'msg_3', body: 'Newest Message', date: now, type: 2 },
+            { id: 'msg_2', body: 'Middle Message', date: now - 5000, type: 1 },
+            { id: 'msg_1', body: 'Oldest Message', date: now - 10000, type: 2 }
+        ];
+        if (window.debugSetMessages) {
+            window.debugSetMessages(messages);
+        }
+    });
+
+    // Wait for messages to render
+    await expect(page.locator('.message')).toHaveCount(3);
+
+    // Verify order: Newest (Top) -> Oldest (Bottom)
+    const firstMsg = page.locator('.message').first();
+    await expect(firstMsg).toContainText('Newest Message');
+
+    const lastMsg = page.locator('.message').last();
+    await expect(lastMsg).toContainText('Oldest Message');
+  });
+
+  test('should add sent message to the top immediately', async ({ page }) => {
+    // Select the first thread
+    await page.locator('.thread-item').first().click();
+
+    // Type a new message
+    const messageBody = 'Brand new message ' + Date.now();
+    await page.locator('.composer-textarea').fill(messageBody);
+
+    // Send
+    await page.locator('button', { hasText: 'Send' }).click();
+
+    // Verify it appears at the TOP (first element)
+    const firstMsg = page.locator('.message').first();
+    await expect(firstMsg).toContainText(messageBody);
+  });
+});


### PR DESCRIPTION
This change improves the Beacon Inbox by reversing the message order to show the newest messages first (at the top) and implementing optimistic UI updates for instant feedback when sending messages. This aligns the app with standard SMS behavior and improves perceived performance.

---
*PR created automatically by Jules for task [8187753837853844812](https://jules.google.com/task/8187753837853844812) started by @DamienLove*