### PR TITLE
Implement immediate SMS sync on premium upgrade via FCM SYNC_REQUEST

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -25,7 +25,7 @@ export {summarizeSmsThread, composeSmsAssist, classifySmsUrgency} from "./ai";
 export {alertRelay, alertRelayHttp} from "./alertRelay";
 export {onMessageCreated, onOutboxCreated} from "./messaging";
 export {sendEmailNotification} from "./email";
-export {findUser, deleteAccount} from "./users";
+export {findUser, deleteAccount, onUserUpdated} from "./users";
 export {approveTheme, onThemeSubmitted} from "./themes";
 export {
   verifySubscription,

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -167,3 +167,73 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
     );
   }
 });
+
+export const onUserUpdated = functions.firestore
+    .document("users/{uid}")
+    .onUpdate(async (change, context) => {
+      const before = change.before.data();
+      const after = change.after.data();
+
+      // Check if premium status changed to active/grace period
+      const wasPremium =
+          before.premiumSubscriptionStatus === "SUBSCRIPTION_STATE_ACTIVE" ||
+          before.premiumSubscriptionStatus ===
+              "SUBSCRIPTION_STATE_IN_GRACE_PERIOD";
+      const isPremium =
+          after.premiumSubscriptionStatus === "SUBSCRIPTION_STATE_ACTIVE" ||
+          after.premiumSubscriptionStatus ===
+              "SUBSCRIPTION_STATE_IN_GRACE_PERIOD";
+
+      const premiumActivated = !wasPremium && isPremium;
+
+      // Check if remote web access was enabled
+      const accessEnabled =
+          !before.remoteWebAccessEnabled && after.remoteWebAccessEnabled;
+
+      if (premiumActivated || accessEnabled) {
+        const uid = context.params.uid;
+        console.log(
+            `User ${uid} upgraded/enabled access. Triggering SMS sync.`,
+        );
+
+        const db = admin.firestore();
+        const devicesQuery = await db.collection("devices")
+            .where("uid", "==", uid)
+            .get();
+
+        if (devicesQuery.empty) {
+          console.log(`No devices found for user ${uid}`);
+          return;
+        }
+
+        const tokens: string[] = [];
+        devicesQuery.forEach((doc) => {
+          const data = doc.data();
+          if (data.fcmToken) {
+            tokens.push(data.fcmToken);
+          }
+        });
+
+        if (tokens.length === 0) {
+          console.log(`No FCM tokens found for user ${uid}`);
+          return;
+        }
+
+        const payload = {
+          data: {
+            type: "SYNC_REQUEST",
+            timestamp: String(Date.now()),
+          },
+          tokens: tokens,
+        };
+
+        try {
+          const response = await admin.messaging().sendMulticast(payload);
+          console.log(
+              `Sent SYNC_REQUEST to ${response.successCount} devices`,
+          );
+        } catch (error) {
+          console.error("Error sending SYNC_REQUEST notification", error);
+        }
+      }
+    });

--- a/functions/src/users_trigger.test.ts
+++ b/functions/src/users_trigger.test.ts
@@ -1,0 +1,139 @@
+// Mock mocks
+const mockSendMulticast = jest.fn().mockResolvedValue({ successCount: 1 });
+const mockMessaging = jest.fn(() => ({
+  sendMulticast: mockSendMulticast,
+}));
+
+const mockCollection = jest.fn();
+const mockFirestore = jest.fn(() => ({
+  collection: mockCollection,
+}));
+
+jest.mock('firebase-admin', () => ({
+  apps: [],
+  initializeApp: jest.fn(),
+  firestore: mockFirestore,
+  messaging: mockMessaging,
+  auth: () => ({
+      getUserByPhoneNumber: jest.fn(),
+      getUserByEmail: jest.fn(),
+      deleteUser: jest.fn(),
+  }),
+}));
+
+const mockOnUpdate = jest.fn();
+jest.mock('firebase-functions', () => ({
+  firestore: {
+    document: jest.fn(() => ({
+      onUpdate: mockOnUpdate,
+    })),
+  },
+  https: {
+      onCall: jest.fn(),
+      HttpsError: class extends Error {},
+  }
+}));
+
+// Import the module under test
+import { onUserUpdated } from './users';
+
+describe('onUserUpdated Trigger', () => {
+  let wrapped: any;
+
+  beforeAll(() => {
+    // Force usage to avoid TS unused error
+    void onUserUpdated;
+
+    // Extract the handler function from the mock
+    wrapped = mockOnUpdate.mock.calls[0][0];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should send SYNC_REQUEST when premium status becomes active', async () => {
+    const beforeData = { premiumSubscriptionStatus: 'free', remoteWebAccessEnabled: false };
+    const afterData = { premiumSubscriptionStatus: 'SUBSCRIPTION_STATE_ACTIVE', remoteWebAccessEnabled: false };
+
+    const change = {
+      before: { data: () => beforeData },
+      after: { data: () => afterData },
+    };
+    const context = { params: { uid: 'test_uid' } };
+
+    // Mock Firestore response for devices
+    const mockGet = jest.fn().mockResolvedValue({
+      empty: false,
+      forEach: (cb: any) => {
+        cb({ data: () => ({ fcmToken: 'token1' }) });
+        cb({ data: () => ({ fcmToken: 'token2' }) });
+      },
+    });
+    const mockWhere = jest.fn().mockReturnValue({ get: mockGet });
+    mockCollection.mockReturnValue({ where: mockWhere });
+
+    await wrapped(change, context);
+
+    expect(mockCollection).toHaveBeenCalledWith('devices');
+    expect(mockWhere).toHaveBeenCalledWith('uid', '==', 'test_uid');
+    expect(mockSendMulticast).toHaveBeenCalledWith(expect.objectContaining({
+      tokens: ['token1', 'token2'],
+      data: expect.objectContaining({ type: 'SYNC_REQUEST' }),
+    }));
+  });
+
+  it('should send SYNC_REQUEST when remoteWebAccessEnabled becomes true', async () => {
+    const beforeData = { premiumSubscriptionStatus: 'free', remoteWebAccessEnabled: false };
+    const afterData = { premiumSubscriptionStatus: 'free', remoteWebAccessEnabled: true };
+
+    const change = {
+      before: { data: () => beforeData },
+      after: { data: () => afterData },
+    };
+    const context = { params: { uid: 'test_uid' } };
+
+    const mockGet = jest.fn().mockResolvedValue({
+        empty: false,
+        forEach: (cb: any) => {
+          cb({ data: () => ({ fcmToken: 'token1' }) });
+        },
+      });
+      const mockWhere = jest.fn().mockReturnValue({ get: mockGet });
+      mockCollection.mockReturnValue({ where: mockWhere });
+
+    await wrapped(change, context);
+
+    expect(mockSendMulticast).toHaveBeenCalled();
+  });
+
+  it('should NOT send SYNC_REQUEST when unrelated fields change', async () => {
+    const beforeData = { premiumSubscriptionStatus: 'free', remoteWebAccessEnabled: false, name: 'Old' };
+    const afterData = { premiumSubscriptionStatus: 'free', remoteWebAccessEnabled: false, name: 'New' };
+
+    const change = {
+      before: { data: () => beforeData },
+      after: { data: () => afterData },
+    };
+    const context = { params: { uid: 'test_uid' } };
+
+    await wrapped(change, context);
+
+    expect(mockSendMulticast).not.toHaveBeenCalled();
+  });
+
+   it('should NOT send SYNC_REQUEST when already premium', async () => {
+      const beforeData = { premiumSubscriptionStatus: 'SUBSCRIPTION_STATE_ACTIVE', remoteWebAccessEnabled: true };
+      const afterData = { premiumSubscriptionStatus: 'SUBSCRIPTION_STATE_ACTIVE', remoteWebAccessEnabled: true, name: 'New' };
+
+      const change = {
+        before: { data: () => beforeData },
+        after: { data: () => afterData },
+      };
+      const context = { params: { uid: 'test_uid' } };
+
+      await wrapped(change, context);
+
+      expect(mockSendMulticast).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Implemented `onUserUpdated` Cloud Function to trigger an immediate SMS sync on user devices when `premiumSubscriptionStatus` becomes active or `remoteWebAccessEnabled` is turned on. This ensures users see their messages on the web immediately after upgrading, without waiting for a polling interval.

*   Added `onUserUpdated` trigger in `functions/src/users.ts`.
*   Exported `onUserUpdated` in `functions/src/index.ts`.
*   Added unit tests in `functions/src/users_trigger.test.ts` verifying the trigger logic.
*   Verified that the Android app's `SmsSyncManager` and `PulseLinkFirebaseMessagingService` are already configured to handle the `SYNC_REQUEST` FCM message type.


---
*PR created automatically by Jules for task [9963475214543710629](https://jules.google.com/task/9963475214543710629) started by @DamienLove*