### PR TITLE
⚡ Bolt: Optimize ThreadItem rendering

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -173,7 +173,7 @@ const areThreadsEqual = (prev, next) => {
          prev.onSelect === next.onSelect &&
          prev.onPin === next.onPin &&
          prev.onArchive === next.onArchive &&
-         prev.contactLookup === next.contactLookup &&
+         prev.contactName === next.contactName &&
          prev.thread.id === next.thread.id &&
          prev.thread.address === next.thread.address &&
          prev.thread.snippet === next.thread.snippet &&
@@ -184,10 +184,8 @@ const areThreadsEqual = (prev, next) => {
 
 // Bolt: Optimized ThreadItem with memo to prevent unnecessary re-renders of the entire list
 // when only the selection state changes or when unrelated threads update.
-const ThreadItem = memo(({ thread, isActive, onSelect, showPreviews, onPin, onArchive, contactLookup }) => {
-  const cleanPhone = (thread.address || '').replace(/\D/g, '');
-  const contact = contactLookup?.[cleanPhone];
-  const name = contact?.displayName || thread.display_name || thread.address;
+const ThreadItem = memo(({ thread, isActive, onSelect, showPreviews, onPin, onArchive, contactName }) => {
+  const name = contactName || thread.display_name || thread.address;
 
   return (
     <div
@@ -2080,18 +2078,23 @@ const Sidebar = memo(({
                 )}
               </div>
             ) : (
-              filteredThreads.map(thread => (
-                <ThreadItem
-                  key={`${thread.lineId || 'legacy'}_${thread.id}`}
-                  thread={thread}
-                  isActive={selectedThreadId === thread.id}
-                  onSelect={onSelect}
-                  showPreviews={showPreviews}
-                  onPin={onPinThread}
-                  onArchive={onArchiveThread}
-                  contactLookup={contactLookup}
-                />
-              ))
+              filteredThreads.map(thread => {
+                const cleanPhone = (thread.address || '').replace(/\D/g, '');
+                const contactName = contactLookup?.[cleanPhone]?.displayName;
+
+                return (
+                  <ThreadItem
+                    key={`${thread.lineId || 'legacy'}_${thread.id}`}
+                    thread={thread}
+                    isActive={selectedThreadId === thread.id}
+                    onSelect={onSelect}
+                    showPreviews={showPreviews}
+                    onPin={onPinThread}
+                    onArchive={onArchiveThread}
+                    contactName={contactName}
+                  />
+                );
+              })
             )}
           </div>
         </>


### PR DESCRIPTION
⚡ Bolt: Optimize ThreadItem rendering

💡 What: Refactored `ThreadItem` to accept a `contactName` string prop instead of the `contactLookup` object. Updated `Sidebar` to perform the contact lookup and pass the resolved name. Updated `areThreadsEqual` to compare names instead of lookup object references.

🎯 Why: The `contactLookup` object reference changes whenever contacts are synced or updated, causing *all* `ThreadItem` components to re-render even if their specific contact data didn't change. This created unnecessary DOM work during syncs.

📊 Impact: Significantly reduces re-renders of the thread list during contact updates.

🔬 Measurement: Verify using React DevTools Profiler or by observing that `ThreadItem` render counts do not increment when `setDeviceContacts` is called with unrelated data. Verified functionally with Playwright tests.

---
*PR created automatically by Jules for task [3947114531397319323](https://jules.google.com/task/3947114531397319323) started by @DamienLove*