### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to user lookup

### DIFF
--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -7,7 +7,41 @@ if (admin.apps.length === 0) {
 
 const db = admin.firestore();
 
-export const findUser = functions.https.onCall(async (data, context) => {
+// Sentinel: Rate limit check to prevent user enumeration
+async function checkUserLookupRateLimit(uid: string): Promise<void> {
+  const MAX_LOOKUPS_PER_HOUR = 30;
+  const now = admin.firestore.Timestamp.now();
+  const oneHourAgo = admin.firestore.Timestamp.fromMillis(
+      now.toMillis() - 60 * 60 * 1000,
+  );
+
+  const lookupsRef = db.collection("rate_limits")
+      .doc(uid)
+      .collection("user_lookups");
+
+  const recentLookups = await lookupsRef
+      .where("timestamp", ">", oneHourAgo)
+      .count()
+      .get();
+
+  if (recentLookups.data().count >= MAX_LOOKUPS_PER_HOUR) {
+    throw new functions.https.HttpsError(
+        "resource-exhausted",
+        "Hourly user lookup limit reached.",
+    );
+  }
+
+  // Log this lookup attempt
+  await lookupsRef.add({
+    timestamp: now,
+  });
+}
+
+export const findUserHandler = async (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: any,
+    context: functions.https.CallableContext,
+) => {
   // Auth check
   if (!context.auth) {
     throw new functions.https.HttpsError(
@@ -15,6 +49,9 @@ export const findUser = functions.https.onCall(async (data, context) => {
         "User must be logged in.",
     );
   }
+
+  // Sentinel: Enforce rate limit
+  await checkUserLookupRateLimit(context.auth.uid);
 
   const {phoneNumber, email} = data;
   if (!phoneNumber && !email) {
@@ -89,11 +126,16 @@ export const findUser = functions.https.onCall(async (data, context) => {
     console.error("Error finding user", error);
     return {found: false};
   }
-});
+};
+
+export const findUser = functions.https.onCall(findUserHandler);
 
 export const deleteAccount = functions.https.onCall(async (_data, context) => {
   if (!context.auth) {
-    throw new functions.https.HttpsError("unauthenticated", "User must be logged in.");
+    throw new functions.https.HttpsError(
+        "unauthenticated",
+        "User must be logged in.",
+    );
   }
 
   const uid = context.auth.uid;
@@ -103,7 +145,9 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
   try {
     const userDocRef = db.collection("users").doc(uid);
     const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ? (userSnap.data()?.deviceId as string | undefined) : undefined;
+    const deviceId = userSnap.exists ?
+        (userSnap.data()?.deviceId as string | undefined) :
+        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
@@ -122,7 +166,9 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
       }
     };
 
-    const deviceQuery = await db.collection("devices").where("uid", "==", uid).get();
+    const deviceQuery = await db.collection("devices")
+        .where("uid", "==", uid)
+        .get();
     deviceQuery.forEach((doc) => queueDelete(doc.ref));
     if (deviceId) {
       queueDelete(db.collection("devices").doc(deviceId));
@@ -134,13 +180,18 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
     // Delete beta agreement tied to device ID (if present)
     if (deviceId) {
-      await db.collection("betaAgreements").doc(deviceId).delete().catch(() => undefined);
+      await db.collection("betaAgreements")
+          .doc(deviceId)
+          .delete()
+          .catch(() => undefined);
     }
 
     // Delete link invites sent by or targeted to the user
     const inviteDeletes: Promise<FirebaseFirestore.WriteResult>[] = [];
     const inviteCollection = db.collection("linkEmailInvites");
-    const senderInvites = await inviteCollection.where("senderUid", "==", uid).get();
+    const senderInvites = await inviteCollection
+        .where("senderUid", "==", uid)
+        .get();
     senderInvites.forEach((doc) => inviteDeletes.push(doc.ref.delete()));
     if (email) {
       const targetInvites = await inviteCollection
@@ -151,7 +202,9 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
     await Promise.all(inviteDeletes);
 
     // Delete link docs containing this uid
-    const linksSnap = await db.collection("links").where("uids", "array-contains", uid).get();
+    const linksSnap = await db.collection("links")
+        .where("uids", "array-contains", uid)
+        .get();
     const linkDeletes = linksSnap.docs.map((doc) => doc.ref.delete());
     await Promise.all(linkDeletes);
 
@@ -159,6 +212,7 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
     await admin.auth().deleteUser(uid);
 
     return {success: true};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     console.error("Account deletion failed", error);
     throw new functions.https.HttpsError(

--- a/functions/src/users_security.test.ts
+++ b/functions/src/users_security.test.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions";
+import {findUserHandler} from "./users";
+
+// Mocks
+jest.mock("firebase-admin", () => {
+  const firestoreMock = {
+    collection: jest.fn(),
+  };
+  // Timestamp mock
+  const Timestamp = {
+    now: jest.fn(() => ({toMillis: () => 1600000000000})), // Fixed time
+    fromMillis: jest.fn((ms) => ({toMillis: () => ms})),
+  };
+
+  return {
+    apps: [{}],
+    initializeApp: jest.fn(),
+    firestore: Object.assign(jest.fn(() => firestoreMock), {Timestamp}),
+    auth: jest.fn(() => ({
+      getUserByPhoneNumber: jest.fn(),
+      getUserByEmail: jest.fn(),
+    })),
+  };
+});
+
+describe("User Security - Rate Limiting", () => {
+  let collectionMock: any;
+  let docMock: any;
+  let subCollectionMock: any;
+  let whereMock: any;
+  let countMock: any;
+  let getMock: any;
+  let addMock: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    addMock = jest.fn();
+    getMock = jest.fn();
+    countMock = jest.fn().mockReturnValue({get: getMock});
+    whereMock = jest.fn().mockReturnValue({count: countMock});
+    subCollectionMock = jest.fn().mockReturnValue({
+      where: whereMock,
+      add: addMock,
+    });
+    docMock = jest.fn().mockReturnValue({collection: subCollectionMock});
+    collectionMock = jest.fn().mockReturnValue({doc: docMock});
+
+    // Inject mocks into the existing db instance used by users.ts
+    const db = admin.firestore();
+    db.collection = collectionMock;
+  });
+
+  const context = {
+    auth: {uid: "attacker-uid", token: {}},
+  } as unknown as functions.https.CallableContext;
+
+  const data = {phoneNumber: "+15550000000"};
+
+  test("should allow lookup if under rate limit", async () => {
+    // Mock count to return 29
+    getMock.mockResolvedValue({data: () => ({count: 29})});
+
+    // Mock user lookup to fail gracefully
+    const authMock = admin.auth() as any;
+    authMock.getUserByPhoneNumber
+        .mockRejectedValue({code: "auth/user-not-found"});
+    authMock.getUserByEmail
+        .mockRejectedValue({code: "auth/user-not-found"});
+
+    await findUserHandler(data, context);
+
+    expect(collectionMock).toHaveBeenCalledWith("rate_limits");
+    expect(docMock).toHaveBeenCalledWith("attacker-uid");
+    expect(subCollectionMock).toHaveBeenCalledWith("user_lookups");
+    expect(countMock).toHaveBeenCalled();
+    expect(addMock).toHaveBeenCalled(); // Should log the attempt
+  });
+
+  test("should deny lookup if rate limit reached", async () => {
+    // Mock count to return 30
+    getMock.mockResolvedValue({data: () => ({count: 30})});
+
+    await expect(findUserHandler(data, context))
+        .rejects.toThrow("Hourly user lookup limit reached.");
+
+    expect(addMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR implements rate limiting for the `findUser` Cloud Function to mitigate user enumeration risks.

**Vulnerability:**
Authenticated users could previously invoke `findUser` an unlimited number of times to check for the existence of phone numbers or emails, potentially harvesting user profiles.

**Fix:**
- Added a `checkUserLookupRateLimit` helper that counts lookup attempts in the last hour using `rate_limits/{uid}/user_lookups` subcollection.
- Enforced a limit of 30 lookups per hour.
- Throws `resource-exhausted` error if the limit is exceeded.
- Added unit tests in `users_security.test.ts` to verify the behavior (mocking Firestore).

**Verification:**
- `npm test src/users_security.test.ts` passed.
- Verified that valid lookups are logged and excessive lookups are rejected in tests.

---
*PR created automatically by Jules for task [6371755619179901226](https://jules.google.com/task/6371755619179901226) started by @DamienLove*