### PR TITLE
Configure iOS entitlements and Info.plist for feature parity

### DIFF
--- a/iosApp/BeaconiOS/Beacon.entitlements
+++ b/iosApp/BeaconiOS/Beacon.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/iosApp/BeaconiOS/Info.plist
+++ b/iosApp/BeaconiOS/Info.plist
@@ -20,6 +20,12 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Authenticate to unlock Private Safe</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string></string>
 	<key>UIRequiresFullScreen</key>

--- a/iosApp/PulseLinkiOS/Info.plist
+++ b/iosApp/PulseLinkiOS/Info.plist
@@ -20,8 +20,14 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Authenticate to cancel emergency</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>PulseLink uses your location to share emergency alerts with trusted contacts.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string></string>
 	<key>UIRequiresFullScreen</key>

--- a/iosApp/PulseLinkiOS/PulseLink.entitlements
+++ b/iosApp/PulseLinkiOS/PulseLink.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
+</dict>
+</plist>

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -23,6 +23,7 @@ targets:
       PRODUCT_BUNDLE_IDENTIFIER: com.pulselink.ios.free
       INFOPLIST_FILE: PulseLinkiOS/Info.plist
       INFOPLIST_KEY_CFBundleDisplayName: PulseLink
+      CODE_SIGN_ENTITLEMENTS: PulseLinkiOS/PulseLink.entitlements
 
   PulseLinkPro:
     type: application
@@ -37,6 +38,7 @@ targets:
       INFOPLIST_FILE: PulseLinkiOS/Info.plist
       SWIFT_ACTIVE_COMPILATION_CONDITIONS: PRO
       INFOPLIST_KEY_CFBundleDisplayName: "PulseLink Pro"
+      CODE_SIGN_ENTITLEMENTS: PulseLinkiOS/PulseLink.entitlements
 
   BeaconFree:
     type: application
@@ -47,6 +49,7 @@ targets:
       PRODUCT_BUNDLE_IDENTIFIER: com.pulselink.beacon.ios.free
       INFOPLIST_FILE: BeaconiOS/Info.plist
       INFOPLIST_KEY_CFBundleDisplayName: Beacon
+      CODE_SIGN_ENTITLEMENTS: BeaconiOS/Beacon.entitlements
 
   BeaconPro:
     type: application
@@ -58,3 +61,4 @@ targets:
       INFOPLIST_FILE: BeaconiOS/Info.plist
       SWIFT_ACTIVE_COMPILATION_CONDITIONS: PRO
       INFOPLIST_KEY_CFBundleDisplayName: "Beacon Pro"
+      CODE_SIGN_ENTITLEMENTS: BeaconiOS/Beacon.entitlements


### PR DESCRIPTION
This change configures the iOS build targets to support Critical Alerts, Background Push Notifications (for data sync), and FaceID.
It creates the missing `.entitlements` files and updates `Info.plist` and `project.yml` to link them correctly.
This addresses the requirement to bring iOS functionality (specifically communication and emergency features) to parity with Android.

---
*PR created automatically by Jules for task [12515922242195700597](https://jules.google.com/task/12515922242195700597) started by @DamienLove*