### PR TITLE
Fix avatar click navigation and home screen theme colors

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -81,7 +81,7 @@
 .brand-logo.small {
   width: 40px;
   height: 40px;
-  filter: drop-shadow(0 0 15px rgba(0, 255, 255, 0.4));
+  filter: drop-shadow(0 0 15px rgba(var(--accent-rgb), 0.4));
   transition: filter 0.3s;
 }
 
@@ -159,11 +159,11 @@
 
 /* "Lit LED" Active State v8 - More Glow */
 .nav-item.active {
-  background: linear-gradient(90deg, rgba(0, 255, 255, 0.15), transparent);
+  background: linear-gradient(90deg, rgba(var(--accent-rgb), 0.15), transparent);
   color: var(--accent);
-  border: 1px solid rgba(0, 255, 255, 0.2);
-  box-shadow: inset 0 0 25px rgba(0, 255, 255, 0.1), 0 0 15px rgba(0, 255, 255, 0.05);
-  text-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
+  border: 1px solid rgba(var(--accent-rgb), 0.2);
+  box-shadow: inset 0 0 25px rgba(var(--accent-rgb), 0.1), 0 0 15px rgba(var(--accent-rgb), 0.05);
+  text-shadow: 0 0 10px rgba(var(--accent-rgb), 0.5);
 }
 
 .nav-item.active::before {
@@ -328,7 +328,7 @@
     90deg,
     transparent,
     rgba(255, 255, 255, 0.05),
-    rgba(0, 255, 255, 0.15),
+    rgba(var(--accent-rgb), 0.15),
     transparent
   );
   transform: skewX(-20deg);
@@ -339,9 +339,9 @@
 .home-card:hover {
   transform: translateY(-8px) scale(1.02);
   border-color: var(--accent);
-  background: rgba(0, 255, 255, 0.06);
+  background: rgba(var(--accent-rgb), 0.06);
   background-position: 100% 100%;
-  box-shadow: 0 30px 60px -12px rgba(0, 0, 0, 0.8), 0 0 30px var(--accent-glow), inset 0 0 20px rgba(0, 255, 255, 0.05);
+  box-shadow: 0 30px 60px -12px rgba(0, 0, 0, 0.8), 0 0 30px var(--accent-glow), inset 0 0 20px rgba(var(--accent-rgb), 0.05);
 }
 
 .home-card:hover::after {
@@ -354,15 +354,15 @@
   border-radius: 14px;
   display: grid;
   place-items: center;
-  background: rgba(0, 255, 255, 0.05);
+  background: rgba(var(--accent-rgb), 0.05);
   color: var(--accent);
   margin-bottom: 2px;
-  border: 1px solid rgba(0, 255, 255, 0.15);
+  border: 1px solid rgba(var(--accent-rgb), 0.15);
   transition: all 0.3s ease;
 }
 
 .home-card:hover .home-icon {
-  background: rgba(0, 255, 255, 0.2);
+  background: rgba(var(--accent-rgb), 0.2);
   border-color: var(--accent);
   box-shadow: 0 0 25px var(--accent-glow);
   transform: rotate(-5deg) scale(1.1);
@@ -424,7 +424,7 @@
     90deg,
     transparent,
     rgba(255, 255, 255, 0.03),
-    rgba(0, 255, 255, 0.1),
+    rgba(var(--accent-rgb), 0.1),
     transparent
   );
   transform: skewX(-20deg);
@@ -433,8 +433,8 @@
 }
 
 .settings-card:hover {
-  border-color: rgba(0, 255, 255, 0.3);
-  box-shadow: 0 10px 40px -10px rgba(0,0,0,0.5), inset 0 0 20px rgba(0, 255, 255, 0.02);
+  border-color: rgba(var(--accent-rgb), 0.3);
+  box-shadow: 0 10px 40px -10px rgba(0,0,0,0.5), inset 0 0 20px rgba(var(--accent-rgb), 0.02);
   transform: translateY(-2px);
 }
 
@@ -497,10 +497,10 @@
 .composer-textarea:focus {
   outline: none;
   border-color: var(--accent);
-  background: rgba(0, 255, 255, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
   box-shadow:
     0 0 0 1px var(--accent),
-    0 0 30px rgba(0, 255, 255, 0.25),
+    0 0 30px rgba(var(--accent-rgb), 0.25),
     inset 0 2px 4px rgba(0,0,0,0.3);
   transform: scale(1.01);
 }
@@ -596,7 +596,7 @@ textarea:focus-visible,
 [role="button"]:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 4px;
-  box-shadow: 0 0 0 4px rgba(0, 255, 255, 0.2);
+  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.2);
   z-index: 10;
 }
 
@@ -611,7 +611,7 @@ textarea:focus-visible,
   font-size: 0.95em;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-  box-shadow: 0 4px 15px -4px rgba(0, 255, 255, 0.4), inset 0 1px 0 rgba(255,255,255,0.4);
+  box-shadow: 0 4px 15px -4px rgba(var(--accent-rgb), 0.4), inset 0 1px 0 rgba(255,255,255,0.4);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -624,13 +624,13 @@ textarea:focus-visible,
 
 .primary-btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 12px 30px -8px rgba(0, 255, 255, 0.6), inset 0 1px 0 rgba(255,255,255,0.6), 0 0 30px var(--accent-glow);
+  box-shadow: 0 12px 30px -8px rgba(var(--accent-rgb), 0.6), inset 0 1px 0 rgba(255,255,255,0.6), 0 0 30px var(--accent-glow);
   filter: brightness(1.1);
 }
 
 .primary-btn:active {
   transform: scale(0.98);
-  box-shadow: 0 2px 10px -4px rgba(0, 255, 255, 0.4);
+  box-shadow: 0 2px 10px -4px rgba(var(--accent-rgb), 0.4);
 }
 
 .primary-btn:disabled {
@@ -753,7 +753,7 @@ textarea:focus-visible,
   font-size: 2.2em;
   font-weight: 700;
   letter-spacing: -0.03em;
-  text-shadow: 0 0 20px rgba(0, 255, 255, 0.2);
+  text-shadow: 0 0 20px rgba(var(--accent-rgb), 0.2);
 }
 
 .login-card p {
@@ -765,7 +765,7 @@ textarea:focus-visible,
   width: 80px;
   height: 80px;
   margin-bottom: 24px;
-  filter: drop-shadow(0 0 40px rgba(0, 255, 255, 0.4));
+  filter: drop-shadow(0 0 40px rgba(var(--accent-rgb), 0.4));
 }
 
 .login-form {
@@ -886,7 +886,7 @@ textarea:focus-visible,
 }
 
 .sidebar-search-wrapper:focus-within {
-  background: rgba(0, 255, 255, 0.05);
+  background: rgba(var(--accent-rgb), 0.05);
   border-color: var(--accent-dim);
   box-shadow: 0 0 0 1px var(--accent-dim);
 }
@@ -947,13 +947,13 @@ textarea:focus-visible,
 }
 
 .thread-item:focus-visible {
-  background: rgba(0, 255, 255, 0.05);
+  background: rgba(var(--accent-rgb), 0.05);
   border-color: var(--accent-dim);
 }
 
 .thread-item.active {
-  background: rgba(0, 255, 255, 0.1);
-  border-color: rgba(0, 255, 255, 0.2);
+  background: rgba(var(--accent-rgb), 0.1);
+  border-color: rgba(var(--accent-rgb), 0.2);
   box-shadow: 0 4px 12px rgba(0,0,0,0.3);
 }
 
@@ -1213,7 +1213,7 @@ textarea:focus-visible,
 
 .compose-status {
   padding: 10px 14px;
-  background: rgba(34, 211, 238, 0.1);
+  background: rgba(var(--accent-rgb), 0.1);
   border: 1px solid var(--accent);
   color: var(--accent);
   border-radius: 12px;
@@ -1327,8 +1327,8 @@ textarea:focus-visible,
 }
 
 .theme-card:hover .theme-preview {
-  border-color: rgba(0, 255, 255, 0.2);
-  box-shadow: inset 0 0 20px rgba(0, 255, 255, 0.1);
+  border-color: rgba(var(--accent-rgb), 0.2);
+  box-shadow: inset 0 0 20px rgba(var(--accent-rgb), 0.1);
 }
 
 .theme-preview-chat {
@@ -1429,8 +1429,8 @@ textarea:focus-visible,
 
 .map-item.active {
   border-color: var(--accent);
-  background: rgba(0, 255, 255, 0.05);
-  box-shadow: 0 0 30px rgba(0, 255, 255, 0.1);
+  background: rgba(var(--accent-rgb), 0.05);
+  box-shadow: 0 0 30px rgba(var(--accent-rgb), 0.1);
 }
 
 .map-badge {
@@ -1631,8 +1631,8 @@ textarea:focus-visible,
   display: flex;
   align-items: flex-start;
   gap: 16px;
-  background: linear-gradient(90deg, rgba(0, 255, 255, 0.1), transparent);
-  border: 1px solid rgba(0, 255, 255, 0.2);
+  background: linear-gradient(90deg, rgba(var(--accent-rgb), 0.1), transparent);
+  border: 1px solid rgba(var(--accent-rgb), 0.2);
   padding: 20px;
   border-radius: 20px;
   margin-bottom: 24px;
@@ -1663,8 +1663,8 @@ textarea:focus-visible,
 }
 
 .web-app-hint .hint-dismiss:hover {
-  background: rgba(0, 255, 255, 0.12);
-  border-color: rgba(0, 255, 255, 0.4);
+  background: rgba(var(--accent-rgb), 0.12);
+  border-color: rgba(var(--accent-rgb), 0.4);
 }
 
 .web-app-hint::before {
@@ -1874,8 +1874,8 @@ textarea:focus-visible,
 .holographic-card {
   position: relative;
   overflow: hidden;
-  border: 1px solid rgba(0, 255, 255, 0.4);
-  box-shadow: 0 0 20px rgba(0, 255, 255, 0.2), inset 0 0 30px rgba(0, 255, 255, 0.05);
+  border: 1px solid rgba(var(--accent-rgb), 0.4);
+  box-shadow: 0 0 20px rgba(var(--accent-rgb), 0.2), inset 0 0 30px rgba(var(--accent-rgb), 0.05);
 }
 
 .holographic-card::before {
@@ -1888,7 +1888,7 @@ textarea:focus-visible,
   background: linear-gradient(
     45deg,
     transparent 45%,
-    rgba(0, 255, 255, 0.15) 50%,
+    rgba(var(--accent-rgb), 0.15) 50%,
     transparent 55%
   );
   animation: hologram-shine 6s infinite linear;
@@ -2026,7 +2026,7 @@ textarea:focus-visible,
 
 .command-palette-item.selected,
 .command-palette-item:hover {
-  background: rgba(0, 255, 255, 0.1);
+  background: rgba(var(--accent-rgb), 0.1);
   color: var(--ink);
 }
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -173,6 +173,7 @@ const areThreadsEqual = (prev, next) => {
          prev.onSelect === next.onSelect &&
          prev.onPin === next.onPin &&
          prev.onArchive === next.onArchive &&
+         prev.onAvatarClick === next.onAvatarClick &&
          prev.contactLookup === next.contactLookup &&
          prev.thread.id === next.thread.id &&
          prev.thread.address === next.thread.address &&
@@ -184,7 +185,7 @@ const areThreadsEqual = (prev, next) => {
 
 // Bolt: Optimized ThreadItem with memo to prevent unnecessary re-renders of the entire list
 // when only the selection state changes or when unrelated threads update.
-const ThreadItem = memo(({ thread, isActive, onSelect, showPreviews, onPin, onArchive, contactLookup }) => {
+const ThreadItem = memo(({ thread, isActive, onSelect, showPreviews, onPin, onArchive, contactLookup, onAvatarClick }) => {
   const cleanPhone = (thread.address || '').replace(/\D/g, '');
   const contact = contactLookup?.[cleanPhone];
   const name = contact?.displayName || thread.display_name || thread.address;
@@ -204,7 +205,25 @@ const ThreadItem = memo(({ thread, isActive, onSelect, showPreviews, onPin, onAr
         }
       }}
     >
-      <Avatar name={name} />
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (onAvatarClick) onAvatarClick(thread);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.stopPropagation();
+            e.preventDefault();
+            if (onAvatarClick) onAvatarClick(thread);
+          }
+        }}
+        aria-label={`View contact info for ${name}`}
+        style={{ display: 'flex', cursor: 'pointer' }}
+      >
+        <Avatar name={name} />
+      </div>
       <div className="thread-main">
         <div className="thread-header">
           {thread.pinned && <PinIcon className="pin-icon" style={{width: 14, height: 14}} />}
@@ -1564,10 +1583,16 @@ const normalizeTheme = (input = {}) => {
   };
 };
 
+const hexToRgb = (hex) => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result ? `${parseInt(result[1], 16)}, ${parseInt(result[2], 16)}, ${parseInt(result[3], 16)}` : '0, 243, 255';
+};
+
 const buildThemeVars = (theme) => {
   const active = normalizeTheme(theme);
   const vars = {
     "--accent": active.primaryColor,
+    "--accent-rgb": hexToRgb(active.primaryColor),
     "--accent-strong": active.secondaryColor,
     "--bg": active.appBackgroundGradientEnd ?? active.backgroundColor,
     "--bg-accent": active.appBackgroundGradientStart ?? active.backgroundColor,
@@ -1785,7 +1810,8 @@ const Sidebar = memo(({
   setShowArchived,
   onPinThread,
   onArchiveThread,
-  contactLookup
+  contactLookup,
+  onAvatarClick
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const searchInputRef = useRef(null);
@@ -2090,6 +2116,7 @@ const Sidebar = memo(({
                   onPin={onPinThread}
                   onArchive={onArchiveThread}
                   contactLookup={contactLookup}
+                  onAvatarClick={onAvatarClick}
                 />
               ))
             )}
@@ -2123,7 +2150,8 @@ const Sidebar = memo(({
          prev.onArchiveThread === next.onArchiveThread &&
          prev.navLogo === next.navLogo &&
          prev.brandTitle === next.brandTitle &&
-         prev.contactLookup === next.contactLookup;
+         prev.contactLookup === next.contactLookup &&
+         prev.onAvatarClick === next.onAvatarClick;
 });
 
 Sidebar.displayName = 'Sidebar';
@@ -3316,7 +3344,7 @@ function App() {
     }
   };
 
-  const resetContactForm = () => {
+  const resetContactForm = useCallback(() => {
     setContactForm({
       displayName: '',
       phoneNumber: '',
@@ -3331,7 +3359,7 @@ function App() {
     });
     setEditingContactId(null);
     setContactStatus('');
-  };
+  }, []);
 
   const handleEditContact = useCallback((contact) => {
     setContactForm({
@@ -3350,6 +3378,24 @@ function App() {
     setContactStatus('');
     setActivePanel('pulselink');
   }, []);
+
+  const handleAvatarClick = useCallback((thread) => {
+    const cleanPhone = (thread.address || '').replace(/\D/g, '');
+    const contact = contactLookup?.[cleanPhone];
+
+    if (contact) {
+      handleEditContact(contact);
+    } else {
+      resetContactForm();
+      setContactForm(prev => ({
+        ...prev,
+        phoneNumber: thread.address || '',
+        displayName: thread.display_name || ''
+      }));
+      setEditingContactId(null);
+      setActivePanel('pulselink');
+    }
+  }, [contactLookup, handleEditContact, resetContactForm]);
 
   const handleSaveContact = async () => {
     if (!user) return;
@@ -4050,6 +4096,7 @@ function App() {
           onPinThread={handlePinThread}
           onArchiveThread={handleArchiveThread}
           contactLookup={contactLookup}
+          onAvatarClick={handleAvatarClick}
         />
         <div className="main-content" id="main-content">
           {activePanel === 'home' && (

--- a/web/tests/avatar_click.spec.js
+++ b/web/tests/avatar_click.spec.js
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test('Avatar click in Beacon Inbox should open Contact Edit form', async ({ page }) => {
+  // 1. Load app with mock user
+  await page.goto('http://localhost:5173/?mock_user=true');
+
+  // 2. Navigate to Beacon panel
+  await page.click('button[title="Beacon"]');
+
+  // 3. Wait for threads to load
+  const threadItem = page.locator('.thread-item').first();
+  await expect(threadItem).toBeVisible();
+
+  // 4. Click the Avatar specifically
+  // The avatar is the first child or class .thread-avatar
+  const avatar = threadItem.locator('.thread-avatar');
+  await avatar.click();
+
+  // 5. Verify we are navigated to the PulseLink panel (Contact Edit)
+  // The panel header should say "PulseLink"
+  const panelHeader = page.locator('.panel-header h3');
+  await expect(panelHeader).toHaveText('PulseLink');
+
+  // 6. Verify the form is populated or ready
+  // Since mock user has 'Test Contact' with '+15559998888' in legacy threads
+  // And trusted contacts has 'Mom' (+15551112222)
+  // If we click the 'Test Contact' (legacy thread), it might not be in trusted list.
+  // So it should open "Add trusted contact" with phone number pre-filled.
+
+  // Let's check the phone input value
+  const phoneInput = page.locator('input[value="+15559998888"]');
+  // OR check if the input with label "Phone" has the value
+  // We can just check if any input has the value.
+
+  // Actually, let's see which thread is first.
+  // In App.jsx mock data:
+  // setLegacyThreads([{ id: 'thread_1', address: '+15559998888', display_name: 'Test Contact', ... }]);
+  // This thread should be visible.
+
+  // After clicking avatar:
+  // Expect "Add trusted contact" header (since it's not in trustedContacts mock list)
+  const formHeader = page.locator('.settings-card h4').filter({ hasText: /Add trusted contact|Edit trusted contact/ });
+  await expect(formHeader).toBeVisible();
+
+  const phoneField = page.locator('input[value="+15559998888"]');
+  await expect(phoneField).toBeVisible();
+});


### PR DESCRIPTION
- **Issue #366:** Implemented `handleAvatarClick` in `App.jsx` to navigate to the contact edit form when an avatar in the Beacon inbox is clicked. Updated `Sidebar` and `ThreadItem` to bubble this event correctly.
- **Issue #363:** Fixed home screen icons not respecting the active theme color by introducing a `--accent-rgb` CSS variable in `App.jsx` and updating `App.css` to use it for dynamic alpha transparency.
- Added `web/tests/avatar_click.spec.js` to verify the avatar click navigation.

---
*PR created automatically by Jules for task [8304905111369724414](https://jules.google.com/task/8304905111369724414) started by @DamienLove*