### PR TITLE
Add Streaming App Support for RingerSong

### DIFF
--- a/ringersong/src/main/AndroidManifest.xml
+++ b/ringersong/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         <package android:name="com.spotify.music" />
         <package android:name="com.apple.android.music" />
         <package android:name="com.google.android.apps.youtube.music" />
+        <package android:name="com.aspiro.tidal" />
     </queries>
 
     <application
@@ -57,6 +58,11 @@
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="audio/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
 

--- a/ringersong/src/main/java/com/RingerSong/free/MainActivity.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/MainActivity.kt
@@ -45,6 +45,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val sharedUriState = mutableStateOf<Uri?>(null)
+    private val sharedTextState = mutableStateOf<String?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,6 +53,7 @@ class MainActivity : ComponentActivity() {
         updateSharedIntent(intent)
         setContent {
             val sharedUri = remember { sharedUriState }
+            val sharedText = remember { sharedTextState }
             // Use hiltViewModel() instead of manually creating via factory
             val viewModel: RingerViewModel = hiltViewModel()
 
@@ -59,7 +61,11 @@ class MainActivity : ComponentActivity() {
                 RingerSongApp(
                     viewModel = viewModel,
                     sharedUri = sharedUri.value,
-                    onSharedConsumed = { sharedUri.value = null }
+                    sharedText = sharedText.value,
+                    onSharedConsumed = {
+                        sharedUri.value = null
+                        sharedText.value = null
+                    }
                 )
             }
         }
@@ -81,10 +87,17 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun updateSharedIntent(intent: Intent?) {
-        if (intent?.action == Intent.ACTION_SEND && intent.type?.startsWith("audio/") == true) {
-            val uri = intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
-            if (uri != null) {
-                sharedUriState.value = uri
+        if (intent?.action == Intent.ACTION_SEND) {
+            if (intent.type?.startsWith("audio/") == true) {
+                val uri = intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+                if (uri != null) {
+                    sharedUriState.value = uri
+                }
+            } else if (intent.type?.startsWith("text/") == true) {
+                val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+                if (!text.isNullOrBlank()) {
+                    sharedTextState.value = text
+                }
             }
         }
     }

--- a/ringersong/src/main/java/com/RingerSong/free/data/Models.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/data/Models.kt
@@ -26,7 +26,8 @@ enum class SongSource {
     SPOTIFY,
     YOUTUBE_MUSIC,
     LOCAL,
-    APPLE_MUSIC // Added for future support
+    APPLE_MUSIC, // Added for future support
+    TIDAL
 }
 
 @Serializable

--- a/ringersong/src/main/java/com/RingerSong/free/data/SpotifyRepository.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/data/SpotifyRepository.kt
@@ -72,6 +72,22 @@ class SpotifyRepository(
         }
     }
 
+    suspend fun getTrack(id: String): SpotifyTrack? = withContext(Dispatchers.IO) {
+        ensureToken()
+        val token = accessToken ?: throw IOException("Could not authenticate with Spotify")
+
+        val request = Request.Builder()
+            .url("https://api.spotify.com/v1/tracks/$id")
+            .header("Authorization", "Bearer $token")
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return@withContext null
+            val body = response.body?.string() ?: return@withContext null
+            gson.fromJson(body, SpotifyTrack::class.java)
+        }
+    }
+
     private fun ensureToken() {
         if (accessToken != null && System.currentTimeMillis() < tokenExpiration) return
 

--- a/ringersong/src/main/java/com/RingerSong/free/service/RingerPlaybackService.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/service/RingerPlaybackService.kt
@@ -34,6 +34,7 @@ class RingerPlaybackService : Service() {
     @Inject lateinit var spotifyPlayer: SpotifyPlayerManager
     @Inject lateinit var appleMusicPlayer: AppleMusicPlayerManager
     @Inject lateinit var youtubeMusicPlayer: YouTubeMusicPlayerManager
+    @Inject lateinit var tidalPlayer: TidalPlayerManager
 
     private val scope = CoroutineScope(Dispatchers.Main + Job())
     private var mediaPlayer: MediaPlayer? = null
@@ -279,6 +280,7 @@ class RingerPlaybackService : Service() {
                 SongSource.LOCAL -> playLocalSong(song, segmentPlay.startMs, segmentPlay.durationMs)
                 SongSource.YOUTUBE_MUSIC -> playYouTubeSong(song, segmentPlay.startMs, segmentPlay.durationMs)
                 SongSource.APPLE_MUSIC -> playAppleMusicSong(song, segmentPlay.startMs, segmentPlay.durationMs)
+                SongSource.TIDAL -> playTidalSong(song, segmentPlay.startMs, segmentPlay.durationMs)
                 else -> {
                     Log.w(TAG, "Unsupported song source: ${song.source}")
                     stopSelf()
@@ -311,6 +313,25 @@ class RingerPlaybackService : Service() {
             stopPlayback()
             restoreSystemRinger()
             stopForeground(true)
+            stopSelf()
+        }
+    }
+
+    private suspend fun playTidalSong(song: SongEntry, startMs: Long, durationMs: Long) {
+        Log.d(TAG, "Attempting to play Tidal song: ${song.title}")
+        val success = tidalPlayer.playTrack(song)
+        if (success) {
+            isPlaying = true
+            playbackJob = scope.launch {
+                delay(durationMs)
+                Log.d(TAG, "Tidal segment duration passed")
+                stopPlayback()
+                restoreSystemRinger()
+                stopForeground(true)
+                stopSelf()
+            }
+        } else {
+            Log.e(TAG, "Failed to launch Tidal")
             stopSelf()
         }
     }

--- a/ringersong/src/main/java/com/RingerSong/free/service/TidalPlayerManager.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/service/TidalPlayerManager.kt
@@ -1,0 +1,73 @@
+package com.RingerSong.free.service
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import com.RingerSong.free.data.SongEntry
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TidalPlayerManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private const val TAG = "TidalPlayerManager"
+        private const val TIDAL_PACKAGE = "com.aspiro.tidal"
+    }
+
+    /**
+     * Attempts to play a Tidal track by launching the app with a deep link.
+     */
+    suspend fun playTrack(song: SongEntry): Boolean = withContext(Dispatchers.Main) {
+        try {
+            // Song URI is expected to be a Tidal URL or URI
+            // e.g., "https://tidal.com/track/12345" or "tidal://track/12345"
+            // or maybe "tidal:track:12345" if we normalize it
+
+            var uriString = song.uri
+
+            // Basic cleanup/normalization if needed
+            if (!uriString.startsWith("http") && !uriString.startsWith("tidal")) {
+                // If just ID?
+                uriString = "https://tidal.com/track/$uriString"
+            }
+
+            val uri = Uri.parse(uriString)
+
+            Log.d(TAG, "Attempting to launch Tidal with URI: $uri")
+
+            // Check for overlay permission
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M &&
+                !android.provider.Settings.canDrawOverlays(context)) {
+                Log.w(TAG, "Cannot launch Tidal: Missing Overlay Permission")
+            }
+
+            val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+                setPackage(TIDAL_PACKAGE)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+
+            val packageManager = context.packageManager
+            if (intent.resolveActivity(packageManager) != null) {
+                context.startActivity(intent)
+                Log.d(TAG, "Tidal intent launched")
+                return@withContext true
+            } else {
+                Log.e(TAG, "Tidal app not installed")
+                // Fallback: try removing package and letting system resolve (might open browser)
+                // But we want Ringer functionality, opening browser might be annoying.
+                // However, user asked to "activate users paid memberships", so app is preferred.
+                return@withContext false
+            }
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error launching Tidal", e)
+            return@withContext false
+        }
+    }
+}

--- a/ringersong/src/main/java/com/RingerSong/free/ui/RingerSongApp.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/ui/RingerSongApp.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.launch
 fun RingerSongApp(
     viewModel: RingerViewModel,
     sharedUri: Uri?,
+    sharedText: String?,
     onSharedConsumed: () -> Unit
 ) {
     val navController = rememberNavController()
@@ -35,13 +36,21 @@ fun RingerSongApp(
     val activity = LocalContext.current as? Activity
     val state = viewModel.state.collectAsStateWithLifecycle()
 
-    LaunchedEffect(sharedUri) {
+    LaunchedEffect(sharedUri, sharedText) {
         if (sharedUri != null) {
             viewModel.addSongs(listOf(sharedUri)) { result ->
                 coroutineScope.launch { snackbarHostState.showResult(result) }
                 if (result.addedCount > 0) {
                     activity?.let { AdServices.showInterstitial(it) }
                 }
+            }
+            onSharedConsumed()
+        } else if (sharedText != null) {
+            viewModel.processSharedText(sharedText) { message ->
+                 coroutineScope.launch { snackbarHostState.showSnackbar(message) }
+                 if (message.startsWith("Added")) {
+                     activity?.let { AdServices.showInterstitial(it) }
+                 }
             }
             onSharedConsumed()
         }

--- a/ringersong/src/main/java/com/RingerSong/free/viewmodel/RingerViewModel.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/viewmodel/RingerViewModel.kt
@@ -740,4 +740,172 @@ class RingerViewModel @Inject constructor(
             onComplete(info)
         }
     }
+
+    fun processSharedText(text: String, onResult: (String) -> Unit) {
+        // Regex patterns for different services
+        val spotifyRegex = Regex("https://open\\.spotify\\.com/track/([a-zA-Z0-9]+)")
+        val tidalRegex = Regex("https://tidal\\.com/(?:browse/)?track/([0-9]+)")
+        val youtubeMusicRegex = Regex("https://music\\.youtube\\.com/watch\\?v=([a-zA-Z0-9_-]+)")
+        val appleMusicRegex = Regex("https://music\\.apple\\.com/([a-z]{2})/album/([^/]+)/([0-9]+)\\?i=([0-9]+)")
+        // Simple apple music song link might be different
+        val appleMusicSongRegex = Regex("https://music\\.apple\\.com/([a-z]{2})/song/([^/]+)/([0-9]+)")
+
+        // Extract URL from text (simple approach: find first http link)
+        val urlMatch = Regex("https?://\\S+").find(text)
+        val url = urlMatch?.value ?: text
+
+        var songEntry: SongEntry? = null
+
+        viewModelScope.launch {
+            when {
+                spotifyRegex.containsMatchIn(url) -> {
+                    val match = spotifyRegex.find(url)
+                    val id = match?.groupValues?.get(1)
+                    if (id != null) {
+                        val track = try {
+                            spotifyRepository.getTrack(id)
+                        } catch (e: Exception) {
+                            null
+                        }
+                        if (track != null) {
+                            addSpotifyTrack(track, onResult)
+                        } else {
+                            onResult("Found Spotify link but could not fetch metadata.")
+                        }
+                        return@launch
+                    }
+                }
+                tidalRegex.containsMatchIn(url) -> {
+                    val match = tidalRegex.find(url)
+                    val id = match?.groupValues?.get(1)
+                    if (id != null) {
+                        val title = extractTitleFromText(text) ?: "Tidal Track $id"
+                        songEntry = SongEntry(
+                            id = UUID.randomUUID().toString(),
+                            title = title,
+                            uri = "https://tidal.com/track/$id",
+                            source = SongSource.TIDAL,
+                            addedAt = System.currentTimeMillis()
+                        )
+                    }
+                }
+                youtubeMusicRegex.containsMatchIn(url) -> {
+                    val match = youtubeMusicRegex.find(url)
+                    val id = match?.groupValues?.get(1)
+                    if (id != null) {
+                        val title = extractTitleFromText(text) ?: "YouTube Music Track"
+                        songEntry = SongEntry(
+                            id = UUID.randomUUID().toString(),
+                            title = title,
+                            uri = "youtube:video:$id",
+                            source = SongSource.YOUTUBE_MUSIC,
+                            addedAt = System.currentTimeMillis()
+                        )
+                    }
+                }
+                appleMusicRegex.containsMatchIn(url) -> {
+                    val match = appleMusicRegex.find(url)
+                    val slug = match?.groupValues?.get(2)
+                    val niceTitle = slug?.replace("-", " ")?.split(" ")?.joinToString(" ") { it.replaceFirstChar { char -> char.uppercase() } }
+                    val title = niceTitle ?: extractTitleFromText(text) ?: "Apple Music Track"
+                    songEntry = SongEntry(
+                        id = UUID.randomUUID().toString(),
+                        title = title,
+                        uri = url,
+                        source = SongSource.APPLE_MUSIC,
+                        addedAt = System.currentTimeMillis()
+                    )
+                }
+                appleMusicSongRegex.containsMatchIn(url) -> {
+                    val match = appleMusicSongRegex.find(url)
+                    val slug = match?.groupValues?.get(2)
+                    val niceTitle = slug?.replace("-", " ")?.split(" ")?.joinToString(" ") { it.replaceFirstChar { char -> char.uppercase() } }
+                    val title = niceTitle ?: extractTitleFromText(text) ?: "Apple Music Track"
+                    songEntry = SongEntry(
+                        id = UUID.randomUUID().toString(),
+                        title = title,
+                        uri = url,
+                        source = SongSource.APPLE_MUSIC,
+                        addedAt = System.currentTimeMillis()
+                    )
+                }
+            }
+
+            if (songEntry != null) {
+                addStreamingTrack(songEntry, onResult)
+            } else {
+                onResult("No supported streaming link found.")
+            }
+        }
+    }
+
+    private fun extractTitleFromText(text: String): String? {
+        // Try to find title if text looks like "Song by Artist"
+        // Or "Check out Song by Artist on Service"
+        // This is very rough.
+        return null
+    }
+
+    private fun addStreamingTrack(songEntry: SongEntry, onResult: (String) -> Unit) {
+        val uid = auth?.currentUser?.uid ?: run {
+            onResult("Error: Please sign in to add songs")
+            return
+        }
+        val safeDb = db ?: run {
+            onResult("Error: Database unavailable")
+            return
+        }
+
+        viewModelScope.launch {
+            val current = state.value
+            if (current.songs.size >= current.settings.maxSongs) {
+                onResult("Playlist is full (max ${current.settings.maxSongs})")
+                return@launch
+            }
+
+            if (current.songs.any { it.uri == songEntry.uri }) {
+                onResult("Song already in playlist")
+                return@launch
+            }
+
+            // Update local state
+            withContext(Dispatchers.IO) {
+                store.update { current ->
+                    val updatedSongs = current.songs + songEntry
+                    val updatedOrder = current.songOrder + songEntry.id
+                    current.copy(songs = updatedSongs, songOrder = updatedOrder)
+                }
+            }
+
+            // Sync to Firestore
+            val trackData = mapOf(
+                "uri" to songEntry.uri,
+                "source" to songEntry.source.name,
+                "title" to songEntry.title,
+                "artist" to "Unknown Artist",
+                "durationMs" to (songEntry.durationMs ?: 0L),
+                "addedAt" to com.google.firebase.Timestamp.now(),
+                "downloaded" to false
+            )
+
+            safeDb.collection("users").document(uid).collection("ringer_playlist")
+                .add(trackData)
+                .addOnSuccessListener {
+                    onResult("Added ${songEntry.title}")
+                }
+                .addOnFailureListener { e ->
+                    // Revert
+                    viewModelScope.launch {
+                        withContext(Dispatchers.IO) {
+                            store.update { current ->
+                                val updatedSongs = current.songs.filter { it.id != songEntry.id }
+                                val updatedOrder = current.songOrder.filter { it != songEntry.id }
+                                current.copy(songs = updatedSongs, songOrder = updatedOrder)
+                            }
+                        }
+                    }
+                    onResult("Failed to sync: ${e.message}")
+                }
+        }
+    }
 }


### PR DESCRIPTION
Implemented support for Tidal, Spotify, YouTube Music, and Apple Music shared links to be used as ringtones. When a link is shared to the app, it is parsed, and the corresponding app is launched during an incoming call to play the track. This leverages the user's installed apps and subscriptions.

---
*PR created automatically by Jules for task [11879092092608326790](https://jules.google.com/task/11879092092608326790) started by @DamienLove*