### PR TITLE
Configure iOS Entitlements and Info.plist for Android Parity

### DIFF
--- a/iosApp/BeaconiOS/Beacon.entitlements
+++ b/iosApp/BeaconiOS/Beacon.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/iosApp/BeaconiOS/Info.plist
+++ b/iosApp/BeaconiOS/Info.plist
@@ -24,6 +24,12 @@
 	<string></string>
 	<key>UIRequiresFullScreen</key>
 	<true/>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Authenticate to unlock Private Safe.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/iosApp/PulseLinkiOS/Info.plist
+++ b/iosApp/PulseLinkiOS/Info.plist
@@ -26,6 +26,12 @@
 	<string></string>
 	<key>UIRequiresFullScreen</key>
 	<true/>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Authenticate to cancel emergency alerts.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/iosApp/PulseLinkiOS/PulseLink.entitlements
+++ b/iosApp/PulseLinkiOS/PulseLink.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.user-notifications.critical-alerts</key>
+	<true/>
+</dict>
+</plist>

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -22,6 +22,7 @@ targets:
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.pulselink.ios.free
       INFOPLIST_FILE: PulseLinkiOS/Info.plist
+      CODE_SIGN_ENTITLEMENTS: PulseLinkiOS/PulseLink.entitlements
       INFOPLIST_KEY_CFBundleDisplayName: PulseLink
 
   PulseLinkPro:
@@ -35,6 +36,7 @@ targets:
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.pulselink.ios.pro
       INFOPLIST_FILE: PulseLinkiOS/Info.plist
+      CODE_SIGN_ENTITLEMENTS: PulseLinkiOS/PulseLink.entitlements
       SWIFT_ACTIVE_COMPILATION_CONDITIONS: PRO
       INFOPLIST_KEY_CFBundleDisplayName: "PulseLink Pro"
 
@@ -46,6 +48,7 @@ targets:
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.pulselink.beacon.ios.free
       INFOPLIST_FILE: BeaconiOS/Info.plist
+      CODE_SIGN_ENTITLEMENTS: BeaconiOS/Beacon.entitlements
       INFOPLIST_KEY_CFBundleDisplayName: Beacon
 
   BeaconPro:
@@ -56,5 +59,6 @@ targets:
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.pulselink.beacon.ios.pro
       INFOPLIST_FILE: BeaconiOS/Info.plist
+      CODE_SIGN_ENTITLEMENTS: BeaconiOS/Beacon.entitlements
       SWIFT_ACTIVE_COMPILATION_CONDITIONS: PRO
       INFOPLIST_KEY_CFBundleDisplayName: "Beacon Pro"


### PR DESCRIPTION
This change updates the iOS project configuration to bring it to functional parity with the Android build.
Specifically, it:
1.  Enables **Critical Alerts** for PulseLink (Free/Pro) to allow high-priority emergency alerts, matching Android's ability to override DND.
2.  Enables **FaceID** usage descriptions for both apps, allowing "Private Safe" unlocking (Beacon) and "Emergency Cancellation" authentication (PulseLink), matching Android's biometric features.
3.  Enables **Background Remote Notifications** for both apps to ensure Firestore data (Chat/Status) remains in sync with the Android "server" device.
4.  Updates `project.yml` to correctly link the newly created `.entitlements` files to the 4 build targets (`PulseLinkFree`, `PulseLinkPro`, `BeaconFree`, `BeaconPro`).

These changes ensure the iOS apps can effectively communicate (receive push updates) and offer the Pro features expected by the user.

---
*PR created automatically by Jules for task [15729248022842749422](https://jules.google.com/task/15729248022842749422) started by @DamienLove*