### PR TITLE
Enable SMS Sync for Web Access by fixing Android worker permissions

### DIFF
--- a/androidApp/src/main/java/com/pulselink/data/sms/SmsSyncWorker.kt
+++ b/androidApp/src/main/java/com/pulselink/data/sms/SmsSyncWorker.kt
@@ -70,7 +70,6 @@ class SmsSyncWorker @AssistedInject constructor(
 
             userRef.set(
                 mapOf(
-                    "subscriptionStatus" to subscriptionTier,
                     "remoteWebAccessEnabled" to settings.remoteWebAccessEnabled
                 ),
                 SetOptions.merge()


### PR DESCRIPTION
The "web access for premium" feature relies on the Android app syncing SMS messages to Firestore. However, the sync worker (`SmsSyncWorker.kt`) was failing because it attempted to write `subscriptionStatus` to the user document. This field is protected by Firestore security rules to prevent client-side spoofing, meaning only the backend (Billing Cloud Functions) can update it.

This change removes the offending write operation from the Android worker. The worker now respects the backend as the source of truth for subscription status while still syncing the `remoteWebAccessEnabled` flag and the actual SMS data.

Verification:
- Manually verified code change in `androidApp/src/main/java/com/pulselink/data/sms/SmsSyncWorker.kt`.
- Ran `web/tests/beacon_inbox.spec.js` and `web/tests/premium_gate.spec.js` to confirm the web frontend correctly handles premium users and displays the inbox when data is present.
- Confirmed `functions` tests pass for billing and security rules.


---
*PR created automatically by Jules for task [5851155524104452340](https://jules.google.com/task/5851155524104452340) started by @DamienLove*