### PR TITLE
Fix issues 68, 76, 77, 78: Wear build, Pro widget, telemetry, and login flicker

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/MainActivity.kt
@@ -958,7 +958,7 @@ class MainActivity : AppCompatActivity() {
                             onAlertsClick = { navController.navigate("alerts_history") { launchSingleTop = true } },
                             showAddLoginPrompt = isSmsOnlyUser,
                             onAddLoginClick = {
-                                navController.navigate("login") {
+                                navController.navigate("login?isUpgrade=true") {
                                     launchSingleTop = true
                                 }
                             },
@@ -1013,7 +1013,11 @@ class MainActivity : AppCompatActivity() {
                             }
                         )
                     }
-                    composable("login") {
+                    composable(
+                        route = "login?isUpgrade={isUpgrade}",
+                        arguments = listOf(navArgument("isUpgrade") { type = NavType.BoolType; defaultValue = false })
+                    ) { entry ->
+                        val isUpgrade = entry.arguments?.getBoolean("isUpgrade") ?: false
                         val loginViewModel: LoginViewModel = hiltViewModel()
                         val loginUiState by loginViewModel.uiState.collectAsStateWithLifecycle()
                         val context = LocalContext.current
@@ -1081,7 +1085,11 @@ class MainActivity : AppCompatActivity() {
                         LaunchedEffect(authState, state.onboardingComplete) {
                             val authenticated = authState as? AuthState.Authenticated
                             if (authenticated != null) {
-                                if (!authenticated.user.isAnonymous || !initialAnonymous) {
+                                // If upgrading (isUpgrade=true), we stay on Login screen even if anonymous, until we are no longer anonymous.
+                                // If fresh launch (isUpgrade=false), we only stay if we started anonymous and are still anonymous (rare edge case),
+                                // otherwise anonymous login should redirect to home (handled by !shouldStay).
+                                val shouldStay = isUpgrade || initialAnonymous
+                                if (!authenticated.user.isAnonymous || !shouldStay) {
                                     val destination = if (state.onboardingComplete) "home" else "onboarding_intro"
                                     navController.navigate(destination) {
                                         popUpTo(0) { inclusive = true }
@@ -1346,7 +1354,7 @@ class MainActivity : AppCompatActivity() {
                             onAlertsClick = { navController.navigate("alerts_history") { launchSingleTop = true } },
                             showAddLoginPrompt = isSmsOnlyUser,
                             onAddLoginClick = {
-                                navController.navigate("login") {
+                                navController.navigate("login?isUpgrade=true") {
                                     launchSingleTop = true
                                 }
                             },
@@ -2299,6 +2307,11 @@ class MainActivity : AppCompatActivity() {
                                     deviceInfo = viewModel.getDeviceInfo(context)
                                 )
                             )
+                        }
+                        LaunchedEffect(Unit) {
+                            if (bugData.deviceInfo.isBlank()) {
+                                bugData = bugData.copy(deviceInfo = viewModel.getDeviceInfo(context))
+                            }
                         }
                         BugReportScreen(
                             data = bugData,

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -6,28 +6,6 @@
         <provider
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
-
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -83,3 +83,7 @@ tasks.register("syncGoogleServices", Copy::class) {
 tasks.matching { it.name == "preBuild" }.configureEach {
     dependsOn("syncGoogleServices")
 }
+
+tasks.withType(com.google.gms.googleservices.GoogleServicesTask::class.java).configureEach {
+    dependsOn("syncGoogleServices")
+}


### PR DESCRIPTION
- Issue 68: Fixed wearApp build failure by adding explicit dependency for GoogleServicesTask on syncGoogleServices in `wearApp/build.gradle.kts`.
- Issue 76: Fixed "No widget on Pro" by removing redundant `PulseLinkWidgetProvider` declaration from `androidApp/src/pro/AndroidManifest.xml` to ensure clean merging with the main manifest.
- Issue 77: Fixed missing telemetry in bug reports by adding a `LaunchedEffect` in `MainActivity.kt` to auto-populate `BugReportData.deviceInfo` if it is blank.
- Issue 78: Fixed "Add Login" screen flicker for anonymous users by introducing an `isUpgrade` navigation argument to the `login` route in `MainActivity.kt`, ensuring users upgrading their account are not automatically redirected to the home screen.

---
*PR created automatically by Jules for task [11368650550092150070](https://jules.google.com/task/11368650550092150070) started by @DamienLove*