### PR TITLE
Fix Ringersong streaming behavior with background WebView player

### DIFF
--- a/ringersong/src/main/java/com/RingerSong/free/service/AppleMusicPlayerManager.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/service/AppleMusicPlayerManager.kt
@@ -13,56 +13,55 @@ import javax.inject.Singleton
 
 @Singleton
 class AppleMusicPlayerManager @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val webViewPlayer: WebViewPlayer
 ) {
     companion object {
         private const val TAG = "AppleMusicPlayer"
         private const val APPLE_MUSIC_PACKAGE = "com.apple.android.music"
     }
 
-    /**
-     * Attempts to play an Apple Music track by launching the app with a deep link.
-     * Note: This is not a true background player like Spotify App Remote.
-     * It relies on the Apple Music app handling the intent.
-     * For a "Ringer" this is a best-effort fallback if streaming API is unavailable.
-     */
     suspend fun playTrack(song: SongEntry): Boolean = withContext(Dispatchers.Main) {
         try {
-            // Apple Music deep link format: https://music.apple.com/us/song/<id> or https://music.apple.com/us/album/<name>/<albumId>?i=<songId>
             val uriString = song.uri
-            val uri = if (uriString.startsWith("http")) {
-                Uri.parse(uriString)
-            } else if (uriString.all { it.isDigit() }) {
-                // If it's just an ID (numeric), try to construct a direct song link
-                // Note: This is a guess. Apple Music IDs usually require album context or 'i=' param.
-                // Fallback to searching/playing by ID if possible via URL scheme
-                Uri.parse("https://music.apple.com/us/song/$uriString")
+
+            // Normalize URI to a valid URL string if possible
+            val fullUrl = if (uriString.all { it.isDigit() }) {
+                "https://music.apple.com/us/song/$uriString"
             } else {
-                // Assume it's a URI we can parse directly (or a different ID format)
-                Uri.parse(uriString)
+                uriString
             }
 
-            Log.d(TAG, "Attempting to launch Apple Music with URI: $uri")
-
-            // Check for overlay permission which is needed to start activity from background on Android 10+
+            // Check for overlay permission
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M &&
-                !android.provider.Settings.canDrawOverlays(context)) {
-                Log.w(TAG, "Cannot launch Apple Music: Missing Overlay Permission")
-                return@withContext false
+                android.provider.Settings.canDrawOverlays(context)) {
+
+                Log.d(TAG, "Overlay permission granted. Using WebViewPlayer.")
+
+                // Convert to embed URL for better web playback support
+                val embedUrl = if (fullUrl.contains("music.apple.com")) {
+                    fullUrl.replace("music.apple.com", "embed.music.apple.com")
+                } else {
+                    fullUrl
+                }
+
+                webViewPlayer.play(embedUrl)
+                return@withContext true
             }
+
+            Log.d(TAG, "Overlay permission missing. Falling back to Intent.")
+
+            // Use the normalized URL for parsing Uri
+            val uri = Uri.parse(fullUrl)
 
             val intent = Intent(Intent.ACTION_VIEW, uri).apply {
                 setPackage(APPLE_MUSIC_PACKAGE)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
 
-            // Verify if Apple Music is installed
             val packageManager = context.packageManager
             if (intent.resolveActivity(packageManager) != null) {
                 context.startActivity(intent)
-                // We return true because we successfully launched the intent.
-                // However, we can't guarantee playback started immediately without user interaction
-                // unless Apple Music supports auto-play on deep link (which it usually does).
                 Log.d(TAG, "Apple Music intent launched")
                 return@withContext true
             } else {
@@ -71,8 +70,12 @@ class AppleMusicPlayerManager @Inject constructor(
             }
 
         } catch (e: Exception) {
-            Log.e(TAG, "Error launching Apple Music", e)
+            Log.e(TAG, "Error playing Apple Music", e)
             return@withContext false
         }
+    }
+
+    suspend fun stop() {
+        webViewPlayer.stop()
     }
 }

--- a/ringersong/src/main/java/com/RingerSong/free/service/RingerPlaybackService.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/service/RingerPlaybackService.kt
@@ -418,10 +418,14 @@ class RingerPlaybackService : Service() {
         playbackJob?.cancel()
         playbackJob = null
 
-        // Ensure we pause Spotify explicitly - simplified logic
+        // Stop our players
         spotifyPlayer.pause()
+        scope.launch {
+            youtubeMusicPlayer.stop()
+            appleMusicPlayer.stop()
+        }
 
-        // Attempt to stop external players (like Apple Music) by sending a media pause key event
+        // Attempt to stop external players (like Apple Music app if fallback used) by sending a media pause key event
         // This is a workaround since we don't control the external app directly.
         try {
             audioManager?.let { am ->

--- a/ringersong/src/main/java/com/RingerSong/free/service/WebViewPlayer.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/service/WebViewPlayer.kt
@@ -1,0 +1,85 @@
+package com.RingerSong.free.service
+
+import android.content.Context
+import android.graphics.PixelFormat
+import android.os.Build
+import android.util.Log
+import android.view.Gravity
+import android.view.WindowManager
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WebViewPlayer @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private var webView: WebView? = null
+    private var windowManager: WindowManager? = null
+
+    companion object {
+        private const val TAG = "WebViewPlayer"
+    }
+
+    suspend fun play(url: String) = withContext(Dispatchers.Main) {
+        stop() // Cleanup any existing
+
+        Log.d(TAG, "Initializing WebView for playback: $url")
+
+        try {
+            windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+            webView = WebView(context).apply {
+                settings.javaScriptEnabled = true
+                settings.mediaPlaybackRequiresUserGesture = false
+                settings.domStorageEnabled = true
+                webViewClient = WebViewClient()
+                loadUrl(url)
+            }
+
+            val params = WindowManager.LayoutParams(
+                1, 1, // 1x1 pixel
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                    WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                else
+                    @Suppress("DEPRECATION")
+                    WindowManager.LayoutParams.TYPE_PHONE,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                        WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                PixelFormat.TRANSLUCENT
+            ).apply {
+                gravity = Gravity.TOP or Gravity.START
+                x = 0
+                y = 0
+            }
+
+            windowManager?.addView(webView, params)
+            Log.d(TAG, "WebView added to WindowManager")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error initializing WebViewPlayer", e)
+            stop()
+        }
+    }
+
+    suspend fun stop() = withContext(Dispatchers.Main) {
+        try {
+            if (webView != null) {
+                Log.d(TAG, "Stopping WebViewPlayer")
+                webView?.loadUrl("about:blank")
+                if (webView?.parent != null) {
+                    windowManager?.removeView(webView)
+                }
+                webView?.destroy()
+                webView = null
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping WebViewPlayer", e)
+        }
+    }
+}

--- a/ringersong/src/main/java/com/RingerSong/free/service/YouTubeMusicPlayerManager.kt
+++ b/ringersong/src/main/java/com/RingerSong/free/service/YouTubeMusicPlayerManager.kt
@@ -13,7 +13,8 @@ import javax.inject.Singleton
 
 @Singleton
 class YouTubeMusicPlayerManager @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val webViewPlayer: WebViewPlayer
 ) {
     companion object {
         private const val TAG = "YouTubeMusicPlayer"
@@ -21,27 +22,30 @@ class YouTubeMusicPlayerManager @Inject constructor(
     }
 
     /**
-     * Attempts to play a YouTube Music track by launching the app with a deep link.
-     * This replaces the "Import/Download" method which relied on unstable 3rd party APIs.
+     * Attempts to play a YouTube Music track.
+     * Tries to use a hidden WebView first (if permission granted),
+     * otherwise falls back to launching the app via deep link.
      */
     suspend fun playTrack(song: SongEntry): Boolean = withContext(Dispatchers.Main) {
         try {
             // Extract video ID from uri "youtube:video:VIDEO_ID"
             val videoId = song.uri.removePrefix("youtube:video:")
 
-            // Construct Deep Link
-            // Tapping this link on Android usually opens YouTube Music if installed
-            val uri = Uri.parse("https://music.youtube.com/watch?v=$videoId")
-
-            Log.d(TAG, "Attempting to launch YouTube Music with URI: $uri")
-
             // Check for overlay permission
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M &&
-                !android.provider.Settings.canDrawOverlays(context)) {
-                Log.w(TAG, "Cannot launch YouTube Music: Missing Overlay Permission")
-                // We might fail here if strictly background, but let's try just in case
-                // (CallStateReceiver usually ensures we are okay or starts service foreground)
+                android.provider.Settings.canDrawOverlays(context)) {
+
+                Log.d(TAG, "Overlay permission granted. Using WebViewPlayer.")
+                // https://www.youtube.com/embed/$videoId?autoplay=1&playsinline=1
+                val embedUrl = "https://www.youtube.com/embed/$videoId?autoplay=1&playsinline=1"
+                webViewPlayer.play(embedUrl)
+                return@withContext true
             }
+
+            Log.d(TAG, "Overlay permission missing. Falling back to Intent.")
+
+            // Construct Deep Link
+            val uri = Uri.parse("https://music.youtube.com/watch?v=$videoId")
 
             val intent = Intent(Intent.ACTION_VIEW, uri).apply {
                 setPackage(YOUTUBE_MUSIC_PACKAGE)
@@ -59,8 +63,12 @@ class YouTubeMusicPlayerManager @Inject constructor(
             }
 
         } catch (e: Exception) {
-            Log.e(TAG, "Error launching YouTube Music", e)
+            Log.e(TAG, "Error playing YouTube Music", e)
             return@withContext false
         }
+    }
+
+    suspend fun stop() {
+        webViewPlayer.stop()
     }
 }


### PR DESCRIPTION
This change improves the Ringersong experience by playing YouTube Music and Apple Music in a hidden background WebView (when overlay permission is granted) instead of launching the full application which obscures the call screen. This aligns with the user request to "activate users paid memberships" while maintaining a seamless ringer experience. The implementation includes a fallback to the previous behavior if permissions are missing.

---
*PR created automatically by Jules for task [17175902551144075070](https://jules.google.com/task/17175902551144075070) started by @DamienLove*