### PR TITLE
Fix Android/Wear Build Issues and Enhance Telemetry

### DIFF
--- a/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
+++ b/androidApp/src/main/java/com/pulselink/ui/state/MainViewModel.kt
@@ -1484,12 +1484,18 @@ class MainViewModel @Inject constructor(
         val model = Build.MODEL.orEmpty()
         val osVersion = Build.VERSION.RELEASE ?: "unknown"
         val apiLevel = Build.VERSION.SDK_INT
+        val density = context.resources.displayMetrics.density
+        val locale = context.resources.configuration.locales[0]
 
         return buildString {
             appendLine("App Version: $versionName ($versionCode)")
-            appendLine("Build Flavor: ${if (BuildConfig.PREMIUM_FEATURES) "Premium" else if (BuildConfig.PRO_FEATURES) "Pro" else "Free"}")
+            appendLine("Flavor: ${BuildConfig.FLAVOR}")
+            appendLine("Build Type: ${BuildConfig.BUILD_TYPE}")
+            appendLine("Feature Level: ${if (BuildConfig.PREMIUM_FEATURES) "Premium" else if (BuildConfig.PRO_FEATURES) "Pro" else "Free"}")
             appendLine("Device: $manufacturer $model")
             appendLine("OS: Android $osVersion (API $apiLevel)")
+            appendLine("Density: $density")
+            appendLine("Locale: $locale")
         }
     }
 

--- a/androidApp/src/pro/AndroidManifest.xml
+++ b/androidApp/src/pro/AndroidManifest.xml
@@ -6,28 +6,6 @@
         <provider
             android:name="com.google.android.gms.ads.MobileAdsInitProvider"
             tools:node="remove" />
-
-        <!-- Home screen widget (available in all flavors, incl. Pro) -->
-        <receiver
-            android:name="com.pulselink.widget.PulseLinkWidgetProvider"
-            android:exported="true"
-            android:icon="@drawable/widget_logo"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-            </intent-filter>
-            <meta-data
-                android:name="android.appwidget.provider"
-                android:resource="@xml/widget_info" />
-        </receiver>
-        <receiver
-            android:name=".widget.PulseLinkWidgetActionReceiver"
-            android:exported="false" />
-
-        <service
-            android:name=".widget.PulseLinkWidgetService"
-            android:permission="android.permission.BIND_REMOTEVIEWS"
-            android:exported="true" />
     </application>
 
 </manifest>

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import com.google.gms.googleservices.GoogleServicesTask
 
 plugins {
     id("com.android.application")
@@ -81,5 +82,9 @@ tasks.register("syncGoogleServices", Copy::class) {
 }
 
 tasks.matching { it.name == "preBuild" }.configureEach {
+    dependsOn("syncGoogleServices")
+}
+
+tasks.withType(GoogleServicesTask::class.java).configureEach {
     dependsOn("syncGoogleServices")
 }


### PR DESCRIPTION
Addressed three open issues:
1.  **Issue #76 (Widget on Pro):** Removed the redundant `PulseLinkWidgetProvider` declaration from `androidApp/src/pro/AndroidManifest.xml` to ensure it correctly inherits from the main manifest and appears in the widget picker for the Pro flavor.
2.  **Issue #77 (Bug Report Details):** Updated `MainViewModel.kt` to include `Flavor`, `Build Type`, `Density`, and `Locale` in the `getDeviceInfo` function, providing richer context for bug reports.
3.  **Issue #68 (Watch App Build Failure):** Fixed a build failure in `wearApp` by adding an explicit dependency for `GoogleServicesTask` on `syncGoogleServices` in `wearApp/build.gradle.kts`.

---
*PR created automatically by Jules for task [12072073516320380877](https://jules.google.com/task/12072073516320380877) started by @DamienLove*