### PR TITLE
Enable concurrent immediate SMS sync for premium users

### DIFF
--- a/androidApp/src/main/java/com/pulselink/data/sms/SmsSyncTrigger.kt
+++ b/androidApp/src/main/java/com/pulselink/data/sms/SmsSyncTrigger.kt
@@ -35,8 +35,10 @@ class SmsSyncTrigger @Inject constructor(
 
         val syncRequest = builder.build()
 
+        val uniqueWorkName = if (threadId != null) "SmsSyncThread_$threadId" else "SmsSyncFull"
+
         WorkManager.getInstance(context).enqueueUniqueWork(
-            "SmsSyncOnDemand",
+            uniqueWorkName,
             ExistingWorkPolicy.APPEND_OR_REPLACE,
             syncRequest
         )


### PR DESCRIPTION
Implemented immediate, non-blocking SMS synchronization by refining `SmsSyncTrigger` to support concurrent WorkManager tasks.

- **Dynamic Work Names:** Replaced the static "SmsSyncOnDemand" work name with dynamic names: "SmsSyncFull" for full syncs and "SmsSyncThread_<id>" for targeted thread updates.
- **Concurrency:** This allows high-priority thread updates (triggered by incoming/outgoing SMS) to bypass the queue if a full sync is already in progress, ensuring the web interface reflects new messages instantly.
- **Compliance:** Aligns with the requirement for "no interval syncs just immediate direct when needed" by removing the serialization bottleneck.

---
*PR created automatically by Jules for task [9217167463735666040](https://jules.google.com/task/9217167463735666040) started by @DamienLove*