### PR TITLE
🎨 Palette: Add loading states to Settings sync buttons

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2282,6 +2282,8 @@ function App() {
   const [settingsStatus, setSettingsStatus] = useState('');
   const [remoteSettingsStatus, setRemoteSettingsStatus] = useState('');
   const [isSavingSettings, setIsSavingSettings] = useState(false);
+  const [isTestingRelay, setIsTestingRelay] = useState(false);
+  const [isRequestingSync, setIsRequestingSync] = useState(false);
   const [syncDiagnostics, setSyncDiagnostics] = useState(null);
   const [relayDiagnostics, setRelayDiagnostics] = useState(null);
   const [syncRequestStatus, setSyncRequestStatus] = useState('');
@@ -3554,6 +3556,7 @@ function App() {
 
   const handleTestRelay = async () => {
     if (!user) return;
+    setIsTestingRelay(true);
     setRemoteSettingsStatus("Queueing test message...");
     try {
       const phone = profile.phoneNumber || user.phoneNumber;
@@ -3573,11 +3576,14 @@ function App() {
     } catch (e) {
       console.error("Test relay failed", e);
       setRemoteSettingsStatus("Test failed: " + e.message);
+    } finally {
+      setIsTestingRelay(false);
     }
   };
 
   const requestPhoneSync = async () => {
     if (!user) return;
+    setIsRequestingSync(true);
     setSyncRequestStatus("Requesting sync...");
     try {
       await setDoc(
@@ -3594,6 +3600,8 @@ function App() {
     } catch (error) {
       console.error("Sync request failed", error);
       setSyncRequestStatus(error?.message ?? "Unable to request sync.");
+    } finally {
+      setIsRequestingSync(false);
     }
   };
 
@@ -5174,16 +5182,30 @@ function App() {
                               type="button"
                               onClick={requestPhoneSync}
                               style={{ flex: 1 }}
+                              disabled={isRequestingSync}
+                              aria-busy={isRequestingSync}
                             >
-                              Request phone sync
+                              {isRequestingSync ? (
+                                <>
+                                  <Spinner />
+                                  Requesting...
+                                </>
+                              ) : 'Request phone sync'}
                             </button>
                             <button
                               className="secondary-btn"
                               type="button"
                               onClick={handleTestRelay}
                               style={{ flex: 1 }}
+                              disabled={isTestingRelay}
+                              aria-busy={isTestingRelay}
                             >
-                              Test relay
+                              {isTestingRelay ? (
+                                <>
+                                  <Spinner />
+                                  Testing...
+                                </>
+                              ) : 'Test relay'}
                             </button>
                           </div>
                           {remoteSettingsStatus && <div className={getToastClass(remoteSettingsStatus)} role="status" aria-live="polite">{remoteSettingsStatus}</div>}


### PR DESCRIPTION
This PR improves the UX of the Settings panel by adding visual feedback for asynchronous actions.
- **Problem:** The "Request phone sync" and "Test relay" buttons offered no feedback when clicked, leaving users unsure if the action was processing.
- **Solution:** Implemented loading states using the existing `<Spinner />` component.
- **Changes:**
  - Modified `web/src/App.jsx` to track loading status for these actions.
  - Buttons now display a spinner and updated text while processing.
  - Buttons are disabled during processing to prevent multiple submissions.
- **Accessibility:** Added `aria-busy="true"` to the buttons when in the loading state.

---
*PR created automatically by Jules for task [1931256808514681177](https://jules.google.com/task/1931256808514681177) started by @DamienLove*